### PR TITLE
Remove trailing space from permissionName

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "visible": true
       },
       {
-        "permissionName": "ui-erm-usage.view ",
+        "permissionName": "ui-erm-usage.view",
         "displayName": "eUsage: Can view usage data providers and COUNTER reports",
         "description": "Can view usage data providers and COUNTER reports",
         "subPermissions": [


### PR DESCRIPTION
The trailing space in `ui-erm-usage.view` was found while attempting to install `platform-erm` onto a Vagrant box with Stripes CLI.  This caused the permission name not to be found while attempting to assign permissions to a user.  I suspect the extra space is not intentional.