### PR TITLE
use own translation values

### DIFF
--- a/src/components/views/UDP.js
+++ b/src/components/views/UDP.js
@@ -86,7 +86,7 @@ class UDP extends React.Component {
     return (
       <PaneMenu>
         {tagsEnabled && (
-          <FormattedMessage id="ui-users.showTags">
+          <FormattedMessage id="ui-erm-usage.showTags">
             {(ariaLabel) => (
               <PaneHeaderIconButton
                 icon="tag"

--- a/translations/ui-erm-usage/en.json
+++ b/translations/ui-erm-usage/en.json
@@ -216,5 +216,7 @@
   "settings.harvester.config.periodic.periodicInterval": "Periodic interval",
   "settings.harvester.config.periodic.lastTriggered": "Last triggered at",
   "settings.harvester.config.periodic.notDefined": "Periodic harvesting is not defined and thus not enabled. Click + to define periodic harvesting.",
-  "settings.harvester.config.periodic.deleteQuestion": "Do you really want to delete the periodic harvesting config?"
+  "settings.harvester.config.periodic.deleteQuestion": "Do you really want to delete the periodic harvesting config?",
+
+  "showTags": "Show tags"
 }


### PR DESCRIPTION
Do not rely on translation keys from other UI apps which may not be
present on a platform. (And which are very VERY noisy when they are
missing during tests.)