### PR TITLE
UIEUS-227: Non-counter upload: store link instead of file

### DIFF
--- a/src/components/ReportUpload/FileUploader.js
+++ b/src/components/ReportUpload/FileUploader.js
@@ -1,14 +1,9 @@
 import _ from 'lodash';
 import React from 'react';
-import {
-  injectIntl,
-  FormattedMessage
-} from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import Dropzone from 'react-dropzone';
-import {
-  Button
-} from '@folio/stripes/components';
+import { Button } from '@folio/stripes/components';
 
 class FileUploader extends React.Component {
   static propTypes = {
@@ -16,17 +11,22 @@ class FileUploader extends React.Component {
     onClickUpload: PropTypes.func,
     selectedFile: PropTypes.object,
     intl: PropTypes.object,
-  }
+  };
 
   onDrop = (acceptedFiles) => {
     this.props.onSelectFile(acceptedFiles);
-  }
+  };
 
   renderUploadButton = () => {
-    if (_.isEmpty(this.props.selectedFile) || _.isNil(this.props.onClickUpload)) {
+    if (
+      _.isEmpty(this.props.selectedFile) ||
+      _.isNil(this.props.onClickUpload)
+    ) {
       return null;
     } else {
-      const upload = this.props.intl.formatMessage({ id: 'ui-erm-usage.report.upload.upload' });
+      const upload = this.props.intl.formatMessage({
+        id: 'ui-erm-usage.report.upload.upload',
+      });
       return (
         <Button
           aria-label={`Upload counter report file ${this.props.selectedFile.name}`}
@@ -37,45 +37,47 @@ class FileUploader extends React.Component {
         </Button>
       );
     }
-  }
+  };
 
   render() {
     const baseStyle = {
-      'display': 'flex',
-      'alignItems': 'center',
-      'flexDirection': 'column',
-      'justifyContent': 'center',
-      'height': '100%',
-      'borderWidth': '2',
-      'borderColor': '#666',
-      'borderStyle': 'dashed',
-      'borderRadius': '5'
+      display: 'flex',
+      alignItems: 'center',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      height: '100%',
+      borderWidth: '2',
+      borderColor: '#666',
+      borderStyle: 'dashed',
+      borderRadius: '5',
     };
 
     const style = { ...baseStyle };
     return (
-      <Dropzone
-        onDrop={this.onDrop}
-        multiple={false}
-      >
-        {({ getRootProps, getInputProps, open }) => (
-          <div {...getRootProps({ onClick: evt => evt.preventDefault() })}>
-            <div style={style}>
-              <input {...getInputProps()} />
-              <FormattedMessage aria-label="Drop file for counter report upload" id="ui-erm-usage.report.upload.dropFile" />
-              <Button
-                aria-label="Or select file for counter report upload"
-                buttonStyle="primary"
-                id="upload-file-button"
-                onClick={() => open()}
-              >
-                <FormattedMessage id="ui-erm-usage.report.upload.selectFile" />
-              </Button>
-              {this.renderUploadButton()}
+      <div id="upload-file-zone">
+        <Dropzone onDrop={this.onDrop} multiple={false}>
+          {({ getRootProps, getInputProps, open }) => (
+            <div {...getRootProps({ onClick: (evt) => evt.preventDefault() })}>
+              <div style={style}>
+                <input {...getInputProps()} />
+                <FormattedMessage
+                  aria-label="Drop file for counter report upload"
+                  id="ui-erm-usage.report.upload.dropFile"
+                />
+                <Button
+                  aria-label="Or select file for counter report upload"
+                  buttonStyle="primary"
+                  id="upload-file-button"
+                  onClick={() => open()}
+                >
+                  <FormattedMessage id="ui-erm-usage.report.upload.selectFile" />
+                </Button>
+                {this.renderUploadButton()}
+              </div>
             </div>
-          </div>
-        )}
-      </Dropzone>
+          )}
+        </Dropzone>
+      </div>
     );
   }
 }

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
@@ -179,6 +179,7 @@ function NonCounterUpload(props) {
             <Col xs={10}>
               <RadioButton
                 checked={useFile}
+                id="custom-report-file-radio"
                 inline
                 onChange={() => {
                   setUseFile(!useFile);
@@ -189,6 +190,7 @@ function NonCounterUpload(props) {
               />
               <RadioButton
                 checked={!useFile}
+                id="custom-report-link-radio"
                 inline
                 onChange={() => {
                   setUseFile(!useFile);

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
@@ -4,12 +4,7 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
 import _ from 'lodash';
 import { CalloutContext } from '@folio/stripes/core';
-import {
-  Col,
-  Row,
-  TextField,
-  RadioButton,
-} from '@folio/stripes/components';
+import { Col, Row, TextField, RadioButton } from '@folio/stripes/components';
 
 import NonCounterUploadFile from './NonCounterUploadFile';
 import NonCounterUploadLink from './NonCounterUploadLink';

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
@@ -5,22 +5,16 @@ import { Field } from 'react-final-form';
 import _ from 'lodash';
 import { CalloutContext } from '@folio/stripes/core';
 import {
-  Button,
   Col,
-  Icon,
-  KeyValue,
-  Loading,
-  Label,
   Row,
   TextField,
   RadioButton,
 } from '@folio/stripes/components';
 
-import { validateUrl } from '../../../util/validate';
+import NonCounterUploadFile from './NonCounterUploadFile';
+import NonCounterUploadLink from './NonCounterUploadLink';
 
-import FileUploader from '../FileUploader';
-
-function FileUploadCard(props) {
+function NonCounterUpload(props) {
   const [selectedFile, setSelectedFile] = useState();
   const [fileId, setFileId] = useState();
   const [showUploadModal, setShowUploadModal] = useState(false);
@@ -121,49 +115,6 @@ function FileUploadCard(props) {
     doUploadRawFile(currentFile);
   };
 
-  const renderSelectedFile = () => {
-    const { handlers } = props;
-    let downloadButton = '';
-    if (_.isNil(selectedFile) || _.isNil(fileId)) {
-      downloadButton = (
-        <FormattedMessage id="ui-erm-usage.statistics.custom.selectFileFirst" />
-      );
-    } else {
-      downloadButton = (
-        <Button
-          data-test-doc-file
-          buttonStyle="link"
-          onClick={() => handlers.doDownloadFile(fileId, selectedFile.name)}
-        >
-          <Icon icon="external-link">{selectedFile.name}</Icon>
-        </Button>
-      );
-    }
-    return (
-      <KeyValue
-        label={
-          <Label required>
-            <FormattedMessage id="ui-erm-usage.statistics.custom.selectedFile" />
-          </Label>
-        }
-        value={downloadButton}
-      />
-    );
-  };
-
-  const renderUpload = () => {
-    if (showUploadModal) {
-      return (
-        <>
-          <FormattedMessage id="ui-erm-usage.statistics.counter.upload.wait" />
-          <Loading />
-        </>
-      );
-    } else {
-      return null;
-    }
-  };
-
   const handleLinkUrlChange = (e) => {
     const { mutators, udpId } = props;
     const value = e.target.value;
@@ -175,52 +126,23 @@ function FileUploadCard(props) {
     mutators.setProviderId({}, udpId);
   };
 
-  const renderUploadFile = () => (
-    <Col xs={12} md={12}>
-      <Row>
-        <FormattedMessage id="ui-erm-usage.statistics.custom.selectFileUpload" />
-      </Row>
-      <Row>
-        <Col xs={10}>
-          <FileUploader
-            onSelectFile={handleSelectFile}
-            selectedFile={selectedFile}
-          />
-        </Col>
-      </Row>
-      <Row>
-        <></>
-      </Row>
-      <Row>
-        <Col xs={10}>{renderSelectedFile()}</Col>
-      </Row>
-      <Row>{renderUpload()}</Row>
-    </Col>
-  );
-
-  const renderUploadLink = () => {
-    const error = validateUrl(linkUrl);
-    return (
-      <Col xs={12} md={12}>
-        <Row>
-          <TextField
-            error={error}
-            label={<FormattedMessage id="ui-erm-usage.statistics.custom.linkUrl" />}
-            onChange={handleLinkUrlChange}
-            required
-            valid={error === undefined}
-            value={linkUrl}
-          />
-        </Row>
-      </Col>
-    );
-  };
-
   const renderLinkOrFile = () => {
     if (useFile) {
-      return renderUploadFile();
+      return (
+        <NonCounterUploadFile
+          file={selectedFile}
+          fileId={fileId}
+          isUploading={showUploadModal}
+          onSelectFile={handleSelectFile}
+        />
+      );
     } else {
-      return renderUploadLink();
+      return (
+        <NonCounterUploadLink
+          linkUrl={linkUrl}
+          onChangeLinkUrl={handleLinkUrlChange}
+        />
+      );
     }
   };
 
@@ -261,7 +183,9 @@ function FileUploadCard(props) {
                 onChange={() => {
                   setUseFile(!useFile);
                 }}
-                label={<FormattedMessage id="ui-erm-usage.statistics.custom.uploadFile" />}
+                label={
+                  <FormattedMessage id="ui-erm-usage.statistics.custom.uploadFile" />
+                }
               />
               <RadioButton
                 checked={!useFile}
@@ -269,7 +193,9 @@ function FileUploadCard(props) {
                 onChange={() => {
                   setUseFile(!useFile);
                 }}
-                label={<FormattedMessage id="ui-erm-usage.statistics.custom.linkFile" />}
+                label={
+                  <FormattedMessage id="ui-erm-usage.statistics.custom.linkFile" />
+                }
               />
             </Col>
           </Row>
@@ -282,7 +208,7 @@ function FileUploadCard(props) {
   );
 }
 
-FileUploadCard.propTypes = {
+NonCounterUpload.propTypes = {
   intl: PropTypes.object,
   handlers: PropTypes.shape({
     doDownloadFile: PropTypes.func,
@@ -298,4 +224,4 @@ FileUploadCard.propTypes = {
   udpId: PropTypes.string,
 };
 
-export default injectIntl(FileUploadCard);
+export default injectIntl(NonCounterUpload);

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUpload.js
@@ -101,14 +101,14 @@ function FileUploadCard(props) {
         } else {
           handleFail(
             intl.formatMessage({
-              id: 'ui-erm-usage.report.upload.failed',
+              id: 'ui-erm-usage.report.delete.failed',
             })
           );
         }
       })
       .catch((err) => {
         const failText = intl.formatMessage({
-          id: 'ui-erm-usage.report.upload.failed',
+          id: 'ui-erm-usage.report.delete.failed',
         });
         const infoText = `${failText} ${err.message}`;
         handleFail(infoText);

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadFile.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadFile.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import _ from 'lodash';
+import {
+  Button,
+  Col,
+  Icon,
+  KeyValue,
+  Loading,
+  Label,
+  Row,
+} from '@folio/stripes/components';
+
+import FileUploader from '../FileUploader';
+
+function NonCounterUploadFile(props) {
+  const { fileId, isUploading, onSelectFile, file } = props;
+
+  const renderSelectedFile = () => {
+    const { handlers } = props;
+    let downloadButton = '';
+    if (_.isNil(file) || _.isNil(fileId)) {
+      downloadButton = (
+        <FormattedMessage id="ui-erm-usage.statistics.custom.selectFileFirst" />
+      );
+    } else {
+      downloadButton = (
+        <Button
+          data-test-doc-file
+          buttonStyle="link"
+          onClick={() => handlers.doDownloadFile(fileId, file.name)}
+        >
+          <Icon icon="external-link">{file.name}</Icon>
+        </Button>
+      );
+    }
+    return (
+      <KeyValue
+        label={
+          <Label required>
+            <FormattedMessage id="ui-erm-usage.statistics.custom.selectedFile" />
+          </Label>
+        }
+        value={downloadButton}
+      />
+    );
+  };
+
+  const renderUpload = () => {
+    if (isUploading) {
+      return (
+        <>
+          <FormattedMessage id="ui-erm-usage.statistics.counter.upload.wait" />
+          <Loading />
+        </>
+      );
+    } else {
+      return null;
+    }
+  };
+
+  return (
+    <Col xs={12} md={12}>
+      <Row>
+        <FormattedMessage id="ui-erm-usage.statistics.custom.selectFileUpload" />
+      </Row>
+      <Row>
+        <Col xs={10}>
+          <FileUploader onSelectFile={onSelectFile} selectedFile={file} />
+        </Col>
+      </Row>
+      <Row>
+        <></>
+      </Row>
+      <Row>
+        <Col xs={10}>{renderSelectedFile()}</Col>
+      </Row>
+      <Row>{renderUpload()}</Row>
+    </Col>
+  );
+}
+
+NonCounterUploadFile.propTypes = {
+  file: PropTypes.shape().isRequired,
+  fileId: PropTypes.string.isRequired,
+  handlers: PropTypes.shape({
+    doDownloadFile: PropTypes.func,
+  }),
+  isUploading: PropTypes.bool.isRequired,
+  onSelectFile: PropTypes.func.isRequired,
+};
+
+export default injectIntl(NonCounterUploadFile);

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadFile.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadFile.js
@@ -82,8 +82,8 @@ function NonCounterUploadFile(props) {
 }
 
 NonCounterUploadFile.propTypes = {
-  file: PropTypes.shape().isRequired,
-  fileId: PropTypes.string.isRequired,
+  file: PropTypes.shape(),
+  fileId: PropTypes.string,
   handlers: PropTypes.shape({
     doDownloadFile: PropTypes.func,
   }),

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadLink.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadLink.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import { Col, Row, TextField } from '@folio/stripes/components';
+
+import { validateUrl } from '../../../util/validate';
+
+function NonCounterUploadLink(props) {
+  const { linkUrl, onChangeLinkUrl } = props;
+  const error = validateUrl(linkUrl);
+  return (
+    <Col xs={12} md={12}>
+      <Row>
+        <TextField
+          error={error}
+          label={
+            <FormattedMessage id="ui-erm-usage.statistics.custom.linkUrl" />
+          }
+          onChange={onChangeLinkUrl}
+          required
+          valid={error === undefined}
+          value={linkUrl}
+        />
+      </Row>
+    </Col>
+  );
+}
+
+NonCounterUploadLink.propTypes = {
+  linkUrl: PropTypes.string,
+  onChangeLinkUrl: PropTypes.func.isRequired,
+};
+
+export default injectIntl(NonCounterUploadLink);

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadLink.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadLink.js
@@ -10,7 +10,7 @@ function NonCounterUploadLink(props) {
   const error = validateUrl(linkUrl);
   return (
     <Col xs={12} md={12}>
-      <Row>
+      <Row data-test-report-link-url>
         <TextField
           error={error}
           id="custom-report-link-url"

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadLink.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadLink.js
@@ -13,6 +13,7 @@ function NonCounterUploadLink(props) {
       <Row>
         <TextField
           error={error}
+          id="custom-report-link-url"
           label={
             <FormattedMessage id="ui-erm-usage.statistics.custom.linkUrl" />
           }

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadModal.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadModal.js
@@ -11,9 +11,11 @@ function NonCounterUploadModal(props) {
   const renderFooter = (onSubmit) => (
     <ModalFooter>
       <Button buttonStyle="primary" disabled={invalid} onClick={onSubmit}>
-        Save
+        <FormattedMessage id="ui-erm-usage.general.save" />
       </Button>
-      <Button onClick={onClose}>Cancel</Button>
+      <Button onClick={onClose}>
+        <FormattedMessage id="ui-erm-usage.general.cancel" />
+      </Button>
     </ModalFooter>
   );
 
@@ -86,9 +88,10 @@ export default stripesFinalForm({
   validate: (values) => {
     const errors = {};
     const yyyyRegex = /^[12]\d{3}$/;
-    // if (!values.fileId) {
-    //   errors.fileId = 'Required';
-    // }
+    if (!values.fileId && !values.linkUrl) {
+      errors.fileId = 'Required';
+      errors.linkUrl = 'Required';
+    }
     if (!values.year) {
       errors.year = 'Required';
     } else if (!yyyyRegex.test(values.year)) {

--- a/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadModal.js
+++ b/src/components/ReportUpload/NonCounterUploadModal/NonCounterUploadModal.js
@@ -75,6 +75,9 @@ export default stripesFinalForm({
     setProviderId: (args, state, tools) => {
       tools.changeValue(state, 'providerId', () => args[1]);
     },
+    setLinkUrl: (args, state, tools) => {
+      tools.changeValue(state, 'linkUrl', () => args[1]);
+    },
   },
   subscription: {
     values: true,
@@ -83,9 +86,9 @@ export default stripesFinalForm({
   validate: (values) => {
     const errors = {};
     const yyyyRegex = /^[12]\d{3}$/;
-    if (!values.fileId) {
-      errors.fileId = 'Required';
-    }
+    // if (!values.fileId) {
+    //   errors.fileId = 'Required';
+    // }
     if (!values.year) {
       errors.year = 'Required';
     } else if (!yyyyRegex.test(values.year)) {

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfo.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfo.js
@@ -1,71 +1,35 @@
+import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
-import { Button, Icon, KeyValue, MenuSection } from '@folio/stripes-components';
-import { ViewMetaData } from '@folio/stripes-smart-components';
+
+import CustomReportInfoFile from './CustomReportInfoFile';
+import CustomReportInfoLink from './CustomReportInfoLink';
 
 function CustomReportInfo(props) {
-  const { customReport } = props;
-  const headerSection = (
-    <MenuSection id="menu-actions" label="Custom Report Info" labelTag="h3">
-      <ViewMetaData metadata={customReport.metadata} />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.usage-data-provider" />}
-        value={props.udpLabel}
-      />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.general.note" />}
-        value={customReport.note}
-      />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.general.year" />}
-        value={customReport.year}
-      />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.general.fileSize.kb" />}
-        value={customReport.fileSize}
-      />
-    </MenuSection>
-  );
-  const actionSection = (
-    <MenuSection id="menu-actions" label="Actions" labelTag="h3">
-      <Button
-        id="download-custom-report-button"
-        buttonStyle="dropdownItem"
-        onClick={() => props.handlers.doDownloadFile(customReport.fileId, customReport.fileName)}
-      >
-        <Icon icon="arrow-down">{`Download ${customReport.fileName}`}</Icon>
-      </Button>
-      <Button
-        id="delete-custom-report-button"
-        buttonStyle="dropdownItem"
-        onClick={props.onDelete}
-      >
-        <Icon icon="arrow-down">Delete custom report</Icon>
-      </Button>
-    </MenuSection>
-  );
+  const { customReport, handlers, onDelete, udpLabel } = props;
 
-  return (
-    <>
-      {headerSection}
-      {actionSection}
-    </>
-  );
+  if (!_.isNil(customReport.fileId)) {
+    return (
+      <CustomReportInfoFile
+        customReport={customReport}
+        onDelete={onDelete}
+        udpLabel={udpLabel}
+        handlers={handlers}
+      />
+    );
+  } else {
+    return (
+      <CustomReportInfoLink
+        customReport={customReport}
+        onDelete={onDelete}
+        udpLabel={udpLabel}
+      />
+    );
+  }
 }
 
 CustomReportInfo.propTypes = {
   onDelete: PropTypes.func.isRequired,
-  stripes: PropTypes.shape({
-    connect: PropTypes.func,
-    okapi: PropTypes.shape({
-      url: PropTypes.string.isRequired,
-      tenant: PropTypes.string.isRequired,
-    }).isRequired,
-    store: PropTypes.shape({
-      getState: PropTypes.func,
-    }),
-  }).isRequired,
   customReport: PropTypes.shape().isRequired,
   udpLabel: PropTypes.string.isRequired,
   handlers: PropTypes.shape({

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoFile.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoFile.js
@@ -2,59 +2,42 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Button, Icon, KeyValue, MenuSection } from '@folio/stripes-components';
-import { ViewMetaData } from '@folio/stripes-smart-components';
+
+import ReportInfoHeader from './ReportInfoHeader';
 
 function CustomReportInfoFile(props) {
   const { customReport, handlers, onDelete, udpLabel } = props;
-  const headerSection = (
-    <MenuSection id="menu-actions" label="Custom Report Info" labelTag="h3">
-      <ViewMetaData metadata={customReport.metadata} />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.usage-data-provider" />}
-        value={udpLabel}
-      />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.general.note" />}
-        value={customReport.note}
-      />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.general.year" />}
-        value={customReport.year}
-      />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.general.fileSize.kb" />}
-        value={customReport.fileSize}
-      />
-    </MenuSection>
-  );
-
-  const actionSection = (
-    <MenuSection id="menu-actions" label="Actions" labelTag="h3">
-      <Button
-        id="download-custom-report-button"
-        buttonStyle="dropdownItem"
-        onClick={() =>
-          handlers.doDownloadFile(customReport.fileId, customReport.fileName)
-        }
-      >
-        <Icon icon="arrow-down">{`Download ${customReport.fileName}`}</Icon>
-      </Button>
-      <Button
-        id="delete-custom-report-button"
-        buttonStyle="dropdownItem"
-        onClick={onDelete}
-      >
-        <Icon icon="trash">
-          <FormattedMessage id="ui-erm-usage.statistics.custom.delete" />
-        </Icon>
-      </Button>
-    </MenuSection>
-  );
 
   return (
     <>
-      {headerSection}
-      {actionSection}
+      <ReportInfoHeader customReport={customReport} udpLabel={udpLabel}>
+        <KeyValue
+          label={<FormattedMessage id="ui-erm-usage.general.year" />}
+          value={customReport.year}
+        />
+        <KeyValue
+          label={<FormattedMessage id="ui-erm-usage.general.fileSize.kb" />}
+          value={customReport.fileSize}
+        />
+      </ReportInfoHeader>
+      <MenuSection id="menu-actions" label="Actions" labelTag="h3">
+        <Button
+          id="download-custom-report-button"
+          buttonStyle="dropdownItem"
+          onClick={() => handlers.doDownloadFile(customReport.fileId, customReport.fileName)}
+        >
+          <Icon icon="arrow-down">{`Download ${customReport.fileName}`}</Icon>
+        </Button>
+        <Button
+          id="delete-custom-report-button"
+          buttonStyle="dropdownItem"
+          onClick={onDelete}
+        >
+          <Icon icon="trash">
+            <FormattedMessage id="ui-erm-usage.statistics.custom.delete" />
+          </Icon>
+        </Button>
+      </MenuSection>
     </>
   );
 }

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoFile.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoFile.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Button, Icon, KeyValue, MenuSection } from '@folio/stripes-components';
+import { ViewMetaData } from '@folio/stripes-smart-components';
+
+function CustomReportInfoFile(props) {
+  const { customReport, handlers, onDelete, udpLabel } = props;
+  const headerSection = (
+    <MenuSection id="menu-actions" label="Custom Report Info" labelTag="h3">
+      <ViewMetaData metadata={customReport.metadata} />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.usage-data-provider" />}
+        value={udpLabel}
+      />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.general.note" />}
+        value={customReport.note}
+      />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.general.year" />}
+        value={customReport.year}
+      />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.general.fileSize.kb" />}
+        value={customReport.fileSize}
+      />
+    </MenuSection>
+  );
+
+  const actionSection = (
+    <MenuSection id="menu-actions" label="Actions" labelTag="h3">
+      <Button
+        id="download-custom-report-button"
+        buttonStyle="dropdownItem"
+        onClick={() => handlers.doDownloadFile(customReport.fileId, customReport.fileName)}
+      >
+        <Icon icon="arrow-down">{`Download ${customReport.fileName}`}</Icon>
+      </Button>
+      <Button
+        id="delete-custom-report-button"
+        buttonStyle="dropdownItem"
+        onClick={onDelete}
+      >
+        <Icon icon="arrow-down">Delete custom report</Icon>
+      </Button>
+    </MenuSection>
+  );
+
+  return (
+    <>
+      {headerSection}
+      {actionSection}
+    </>
+  );
+}
+
+CustomReportInfoFile.propTypes = {
+  onDelete: PropTypes.func.isRequired,
+  customReport: PropTypes.shape().isRequired,
+  udpLabel: PropTypes.string.isRequired,
+  handlers: PropTypes.shape({
+    doDownloadFile: PropTypes.func,
+  }),
+};
+
+export default CustomReportInfoFile;

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoFile.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoFile.js
@@ -33,7 +33,9 @@ function CustomReportInfoFile(props) {
       <Button
         id="download-custom-report-button"
         buttonStyle="dropdownItem"
-        onClick={() => handlers.doDownloadFile(customReport.fileId, customReport.fileName)}
+        onClick={() =>
+          handlers.doDownloadFile(customReport.fileId, customReport.fileName)
+        }
       >
         <Icon icon="arrow-down">{`Download ${customReport.fileName}`}</Icon>
       </Button>
@@ -42,7 +44,9 @@ function CustomReportInfoFile(props) {
         buttonStyle="dropdownItem"
         onClick={onDelete}
       >
-        <Icon icon="arrow-down">Delete custom report</Icon>
+        <Icon icon="trash">
+          <FormattedMessage id="ui-erm-usage.statistics.custom.delete" />
+        </Icon>
       </Button>
     </MenuSection>
   );

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
@@ -39,7 +39,9 @@ function CustomReportInfoLink(props) {
         buttonStyle="dropdownItem"
         onClick={onDelete}
       >
-        <Icon icon="trash">Delete custom report</Icon>
+        <Icon icon="trash">
+          <FormattedMessage id="ui-erm-usage.statistics.custom.delete" />
+        </Icon>
       </Button>
     </MenuSection>
   );

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
@@ -13,6 +13,7 @@ function CustomReportInfoLink(props) {
       <ReportInfoHeader customReport={customReport} udpLabel={udpLabel} />
       <MenuSection id="menu-actions" label="Actions" labelTag="h3">
         <TextLink
+          id="custom-report-link"
           target="_blank"
           rel="noopener noreferrer"
           href={customReport.linkUrl}

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import {
+  Button,
+  Icon,
+  KeyValue,
+  MenuSection,
+  TextLink,
+} from '@folio/stripes-components';
+import { ViewMetaData } from '@folio/stripes-smart-components';
+
+function CustomReportInfoLink(props) {
+  const { customReport, onDelete, udpLabel } = props;
+  const headerSection = (
+    <MenuSection id="menu-actions" label="Custom Report Info" labelTag="h3">
+      <ViewMetaData metadata={customReport.metadata} />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.usage-data-provider" />}
+        value={udpLabel}
+      />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.general.note" />}
+        value={customReport.note}
+      />
+    </MenuSection>
+  );
+  const actionSection = (
+    <MenuSection id="menu-actions" label="Actions" labelTag="h3">
+      <TextLink
+        target="_blank"
+        rel="noopener noreferrer"
+        href={customReport.linkUrl}
+      >
+        <Icon icon="external-link">{customReport.linkUrl}</Icon>
+      </TextLink>
+      <Button
+        id="delete-custom-report-button"
+        buttonStyle="dropdownItem"
+        onClick={onDelete}
+      >
+        <Icon icon="trash">Delete custom report</Icon>
+      </Button>
+    </MenuSection>
+  );
+
+  return (
+    <>
+      {headerSection}
+      {actionSection}
+    </>
+  );
+}
+
+CustomReportInfoLink.propTypes = {
+  onDelete: PropTypes.func.isRequired,
+  customReport: PropTypes.shape().isRequired,
+  udpLabel: PropTypes.string.isRequired,
+};
+
+export default CustomReportInfoLink;

--- a/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/CustomReportInfoLink.js
@@ -1,55 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import {
-  Button,
-  Icon,
-  KeyValue,
-  MenuSection,
-  TextLink,
-} from '@folio/stripes-components';
-import { ViewMetaData } from '@folio/stripes-smart-components';
+import { Button, Icon, MenuSection, TextLink } from '@folio/stripes-components';
+
+import ReportInfoHeader from './ReportInfoHeader';
 
 function CustomReportInfoLink(props) {
   const { customReport, onDelete, udpLabel } = props;
-  const headerSection = (
-    <MenuSection id="menu-actions" label="Custom Report Info" labelTag="h3">
-      <ViewMetaData metadata={customReport.metadata} />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.usage-data-provider" />}
-        value={udpLabel}
-      />
-      <KeyValue
-        label={<FormattedMessage id="ui-erm-usage.general.note" />}
-        value={customReport.note}
-      />
-    </MenuSection>
-  );
-  const actionSection = (
-    <MenuSection id="menu-actions" label="Actions" labelTag="h3">
-      <TextLink
-        target="_blank"
-        rel="noopener noreferrer"
-        href={customReport.linkUrl}
-      >
-        <Icon icon="external-link">{customReport.linkUrl}</Icon>
-      </TextLink>
-      <Button
-        id="delete-custom-report-button"
-        buttonStyle="dropdownItem"
-        onClick={onDelete}
-      >
-        <Icon icon="trash">
-          <FormattedMessage id="ui-erm-usage.statistics.custom.delete" />
-        </Icon>
-      </Button>
-    </MenuSection>
-  );
 
   return (
     <>
-      {headerSection}
-      {actionSection}
+      <ReportInfoHeader customReport={customReport} udpLabel={udpLabel} />
+      <MenuSection id="menu-actions" label="Actions" labelTag="h3">
+        <TextLink
+          target="_blank"
+          rel="noopener noreferrer"
+          href={customReport.linkUrl}
+        >
+          <Icon icon="external-link">{customReport.linkUrl}</Icon>
+        </TextLink>
+        <Button
+          id="delete-custom-report-button"
+          buttonStyle="dropdownItem"
+          onClick={onDelete}
+        >
+          <Icon icon="trash">
+            <FormattedMessage id="ui-erm-usage.statistics.custom.delete" />
+          </Icon>
+        </Button>
+      </MenuSection>
     </>
   );
 }

--- a/src/components/Statistics/Custom/CustomReportInfo/ReportInfoHeader.js
+++ b/src/components/Statistics/Custom/CustomReportInfo/ReportInfoHeader.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { KeyValue, MenuSection } from '@folio/stripes-components';
+import { ViewMetaData } from '@folio/stripes-smart-components';
+
+function ReportInfoHeader(props) {
+  const { children, customReport, udpLabel } = props;
+  return (
+    <MenuSection id="menu-actions" label="Custom Report Info" labelTag="h3">
+      <ViewMetaData metadata={customReport.metadata} />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.usage-data-provider" />}
+        value={udpLabel}
+      />
+      <KeyValue
+        label={<FormattedMessage id="ui-erm-usage.general.note" />}
+        value={customReport.note}
+      />
+      {children}
+    </MenuSection>
+  );
+}
+
+ReportInfoHeader.propTypes = {
+  children: PropTypes.node,
+  customReport: PropTypes.shape().isRequired,
+  udpLabel: PropTypes.string.isRequired,
+};
+
+export default ReportInfoHeader;

--- a/src/components/Statistics/Custom/InfoButton/InfoButton.js
+++ b/src/components/Statistics/Custom/InfoButton/InfoButton.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { SubmissionError } from 'redux-form';
@@ -26,7 +27,11 @@ function InfoButton(props) {
     }
   );
 
-  const doDelete = () => {
+  const doDeleteReport = () => {
+    props.mutator.customReport.DELETE({ id: customReport.id }).then(() => {});
+  };
+
+  const doDeleteWithFile = () => {
     fetch(`${props.stripes.okapi.url}/erm-usage/files/${customReport.fileId}`, {
       method: 'DELETE',
       headers: httpHeaders,
@@ -38,14 +43,20 @@ function InfoButton(props) {
             _error: 'Fetch file failed',
           });
         } else {
-          props.mutator.customReport
-            .DELETE({ id: customReport.id })
-            .then(() => {});
+          doDeleteReport();
         }
       })
       .catch((err) => {
         throw new Error('Error while deleting custom report. ' + err.message);
       });
+  };
+
+  const doDelete = () => {
+    if (!_.isNil(customReport.fileId)) {
+      doDeleteWithFile();
+    } else {
+      doDeleteReport();
+    }
     setShowConfirmDelete(false);
   };
 

--- a/src/components/Statistics/Custom/InfoButton/InfoButton.js
+++ b/src/components/Statistics/Custom/InfoButton/InfoButton.js
@@ -71,6 +71,16 @@ function InfoButton(props) {
       Close
     </Button>
   );
+
+  const deleteConfirmMsg = (
+    <FormattedMessage
+      id="ui-erm-usage.reportOverview.deleteTemplateMessage"
+      values={{
+        name: <strong>{`${customReport.year} - ${customReport.note}`}</strong>,
+      }}
+    />
+  );
+
   return (
     <>
       <IconButton
@@ -101,9 +111,7 @@ function InfoButton(props) {
         heading={
           <FormattedMessage id="ui-erm-usage.reportOverview.confirmDelete" />
         }
-        message={
-          <FormattedMessage id="ui-erm-usage.reportOverview.confirmDelete" />
-        }
+        message={deleteConfirmMsg}
         onConfirm={doDelete}
         confirmLabel={<FormattedMessage id="ui-erm-usage.general.yes" />}
         onCancel={() => setShowConfirmDelete(false)}

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -56,6 +56,14 @@ const isYearMonth = value => {
 
 const composeValidators = (...validators) => value => validators.reduce((error, validator) => error || validator(value), undefined);
 
+const validateUrl = value => {
+  const urlRegex = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,})/;
+
+  if (!value || urlRegex.test(value)) return undefined;
+  return <FormattedMessage id="ui-erm-usage.errors.urlRequired" />;
+};
+
+
 export {
   composeValidators,
   endDate,
@@ -63,5 +71,6 @@ export {
   mail,
   notRequired,
   required,
+  validateUrl,
   yearMonth
 };

--- a/test/bigtest/interactors/udp-details-page.js
+++ b/test/bigtest/interactors/udp-details-page.js
@@ -131,6 +131,11 @@ import {
   downloadCustomReportButton = scoped('button[id="download-custom-report-button"]');
   deleteCustomReportButton = scoped('button[id="delete-custom-report-button"]');
   customReportLink = scoped('a[id="custom-report-link"]');
+  closeReportInfoButton = scoped('button[id="close-report-info-button"]');
+}
+
+@interactor class ConfirmDeleteButton {
+  static defaultScope = 'button[data-test-confirmation-modal-confirm-button]';
 }
 
 @interactor class UploadCounterModal {
@@ -187,4 +192,6 @@ export default @interactor class UDPDetailsPage {
 
   clickShowTags = clickable('#clickable-show-tags');
   tagsSelect = new TagsSelect();
+
+  confirmDeleteButton = new ConfirmDeleteButton();
 }

--- a/test/bigtest/interactors/udp-details-page.js
+++ b/test/bigtest/interactors/udp-details-page.js
@@ -114,6 +114,13 @@ const event = { dataTransfer: { files: [file], types: ['Files'] } };
   exist = isPresent();
 }
 
+@interactor class UrlInputError {
+  static defaultScope = 'div[data-test-report-link-url]'
+  // static defaultScope = '[class^="feedbackError---"]';
+  feedbackError = text('[class^="feedbackError---"]');
+  exist = isPresent('[class^="feedbackError---"]');
+}
+
 @interactor class ExpandAll {
   static defaultScope = '#clickable-expand-all-view';
 }
@@ -208,4 +215,5 @@ export default @interactor class UDPDetailsPage {
   confirmDeleteButton = new ConfirmDeleteButton();
   fileUploaderInteractor = new FileUploaderInteractor();
   downloadFileButton = new DownloadFileButton();
+  urlInputError = new UrlInputError();
 }

--- a/test/bigtest/interactors/udp-details-page.js
+++ b/test/bigtest/interactors/udp-details-page.js
@@ -116,7 +116,6 @@ const event = { dataTransfer: { files: [file], types: ['Files'] } };
 
 @interactor class UrlInputError {
   static defaultScope = 'div[data-test-report-link-url]'
-  // static defaultScope = '[class^="feedbackError---"]';
   feedbackError = text('[class^="feedbackError---"]');
   exist = isPresent('[class^="feedbackError---"]');
 }

--- a/test/bigtest/interactors/udp-details-page.js
+++ b/test/bigtest/interactors/udp-details-page.js
@@ -140,7 +140,9 @@ import {
 @interactor class UploadNonCounterModal {
   static defaultScope = '[class="upload-non-counter-modal"]';
   uploadFileButton = scoped('button[id="upload-file-button"]');
+  linkRadioButton = scoped('label[for="custom-report-link-radio"]');
   yearInput = scoped('input[id="custom-report-year"]');
+  linkUrlInput = scoped('input[id="custom-report-link-url"]');
 }
 
 @interactor class TagsSelect {

--- a/test/bigtest/interactors/udp-details-page.js
+++ b/test/bigtest/interactors/udp-details-page.js
@@ -1,4 +1,3 @@
-
 import {
   attribute,
   clickable,
@@ -9,9 +8,21 @@ import {
   property,
   scoped,
   text,
+  triggerable,
   value
 } from '@bigtest/interactor';
 
+const file = new File([], 'Test File', { type: 'text/plain' });
+const event = { dataTransfer: { files: [file], types: ['Files'] } };
+
+@interactor class FileUploaderInteractor {
+  static defaultScope = 'input[type="file"]';
+  drop = triggerable('drop', event);
+}
+
+@interactor class DownloadFileButton {
+  static defaulScope = 'button[data-test-doc-file]';
+}
 
 @interactor class InputFieldInteractor {
   clickInput = clickable();
@@ -146,6 +157,7 @@ import {
 @interactor class UploadNonCounterModal {
   static defaultScope = '[class="upload-non-counter-modal"]';
   uploadFileButton = scoped('button[id="upload-file-button"]');
+  fileRadioButton = scoped('label[for="custom-report-file-radio"]');
   linkRadioButton = scoped('label[for="custom-report-link-radio"]');
   yearInput = scoped('input[id="custom-report-year"]');
   linkUrlInput = scoped('input[id="custom-report-link-url"]');
@@ -194,4 +206,6 @@ export default @interactor class UDPDetailsPage {
   tagsSelect = new TagsSelect();
 
   confirmDeleteButton = new ConfirmDeleteButton();
+  fileUploaderInteractor = new FileUploaderInteractor();
+  downloadFileButton = new DownloadFileButton();
 }

--- a/test/bigtest/interactors/udp-details-page.js
+++ b/test/bigtest/interactors/udp-details-page.js
@@ -130,6 +130,7 @@ import {
   static defaultScope = '[class="custom-report-info"]';
   downloadCustomReportButton = scoped('button[id="download-custom-report-button"]');
   deleteCustomReportButton = scoped('button[id="delete-custom-report-button"]');
+  customReportLink = scoped('a[id="custom-report-link"]');
 }
 
 @interactor class UploadCounterModal {

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -175,6 +175,14 @@ export default function config() {
     errorCodes: ['other', '3000', '3031']
   });
 
+  this.delete('/custom-reports/:id', (schema, request) => {
+    return schema.customReports.find(request.params.id).destroy();
+  });
+
+  this.delete('/erm-usage/files/:id', (schema, request) => {
+    return {};
+  }, 204);
+
   this.get('/custom-reports', (schema, request) => {
     if (request.queryParams) {
       /*

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -179,9 +179,16 @@ export default function config() {
     return schema.customReports.find(request.params.id).destroy();
   });
 
-  this.delete('/erm-usage/files/:id', (schema, request) => {
+  this.delete('/erm-usage/files/:id', (_schema, _request) => {
     return {};
   }, 204);
+
+  this.post('/erm-usage/files', (_schema, _request) => {
+    return {
+      id: 'c120cf58-5e61-4b8a-85c9-a24a80b11903',
+      size: 1912
+    };
+  }, 200);
 
   this.get('/custom-reports', (schema, request) => {
     if (request.queryParams) {

--- a/test/bigtest/network/factories/usage-data-provider.js
+++ b/test/bigtest/network/factories/usage-data-provider.js
@@ -46,6 +46,12 @@ export default Factory.extend({
     }
   }),
 
+  withCustomReportsLinks: trait({
+    afterCreate(provider, server) {
+      server.createList('custom-report', 2, { provider,  fileId: null, fileName: null, fileSize: null, linkUrl: 'https://www.abc.com' });
+    }
+  }),
+
   withSetInactive: trait({
     afterCreate(provider, _) {
       provider.harvestingConfig.harvestingStatus = 'inactive';

--- a/test/bigtest/tests/details-udp-test.js
+++ b/test/bigtest/tests/details-udp-test.js
@@ -10,7 +10,7 @@ describe('UDPDetailsPage', () => {
   const udpInteractor = new UDPInteractor();
 
   let udp = null;
-  beforeEach(async function() {
+  beforeEach(async function () {
     udp = this.server.create('usage-data-provider', 'withUsageReports');
     await this.visit('/eusage/?filters=harvestingStatus.active');
   });
@@ -23,24 +23,24 @@ describe('UDPDetailsPage', () => {
     expect(udpInteractor.instances().length).to.be.gte(1);
   });
 
-  describe('clicking on the first item', function() {
-    beforeEach(async function() {
+  describe('clicking on the first item', function () {
+    beforeEach(async function () {
       await udpInteractor.instances(0).click();
     });
 
-    it('displays udp label in the pane header', function() {
+    it('displays udp label in the pane header', function () {
       expect(udpDetailsPage.title).to.include(udp.label);
     });
 
-    it('all accordions are present', function() {
+    it('all accordions are present', function () {
       expect(udpDetailsPage.harvestingAccordion.isPresent).to.equal(true);
       expect(udpDetailsPage.sushiCredentialsAccordion.isPresent).to.equal(true);
       expect(udpDetailsPage.statisticsAccordion.isPresent).to.equal(true);
       expect(udpDetailsPage.uploadAccordion.isPresent).to.equal(true);
     });
 
-    describe('all accordions can be expanded', function() {
-      beforeEach(async function() {
+    describe('all accordions can be expanded', function () {
+      beforeEach(async function () {
         await udpDetailsPage.expandAll.click();
       });
 
@@ -50,8 +50,8 @@ describe('UDPDetailsPage', () => {
         );
       });
 
-      describe('all accordions can be collapsed', function() {
-        beforeEach(async function() {
+      describe('all accordions can be collapsed', function () {
+        beforeEach(async function () {
           await udpDetailsPage.expandAll.click();
         });
 
@@ -63,8 +63,8 @@ describe('UDPDetailsPage', () => {
       });
     });
 
-    describe('service type is set correctly', function() {
-      beforeEach(async function() {
+    describe('service type is set correctly', function () {
+      beforeEach(async function () {
         await udpDetailsPage.harvestingAccordion.click();
       });
 
@@ -77,8 +77,8 @@ describe('UDPDetailsPage', () => {
       });
     });
 
-    describe('can select report type for download multi months', function() {
-      beforeEach(async function() {
+    describe('can select report type for download multi months', function () {
+      beforeEach(async function () {
         await udpDetailsPage.statisticsAccordion.click();
       });
 
@@ -160,12 +160,12 @@ describe('UDPDetailsPage', () => {
     });
 
     describe('can open report info menu', () => {
-      beforeEach(async function() {
+      beforeEach(async function () {
         await udpDetailsPage.statisticsAccordion.click();
       });
 
       describe('valid report has correct buttons', () => {
-        beforeEach(async function() {
+        beforeEach(async function () {
           await udpDetailsPage.validReport();
         });
 
@@ -180,7 +180,7 @@ describe('UDPDetailsPage', () => {
       });
 
       describe('failed report has correct buttons', () => {
-        beforeEach(async function() {
+        beforeEach(async function () {
           await udpDetailsPage.failedReport();
         });
 
@@ -195,7 +195,7 @@ describe('UDPDetailsPage', () => {
       });
 
       describe('can open tags helper app', () => {
-        beforeEach(async function() {
+        beforeEach(async function () {
           await udpDetailsPage.clickShowTags();
           await udpDetailsPage.tagsSelect.clickable();
         });
@@ -205,147 +205,161 @@ describe('UDPDetailsPage', () => {
         });
       });
     });
-  });
 
-  let initialCustomReports = null;
-  describe('custom reports are listed', function() {
-    beforeEach(async function() {
-      await udpDetailsPage.statisticsAccordion.click();
-      await udpDetailsPage.clickCustomReportAccordion();
-      await udpDetailsPage.clickExpandAllCustomReportYears();
-      initialCustomReports = udpDetailsPage.customReports.instances().length;
-    });
-
-    it('renders custom reports', () => {
-      expect(udpDetailsPage.customReports.instances().length).to.be.gte(1);
-    });
-  });
-
-  describe('custom reports can be selected', function() {
-    beforeEach(async function() {
-      await udpDetailsPage.statisticsAccordion.click();
-      await udpDetailsPage.clickCustomReportAccordion();
-      await udpDetailsPage.clickExpandAllCustomReportYears();
-      await udpDetailsPage.customReports.clickFirstRow();
-    });
-
-    it('renders custom report details', () => {
-      expect(
-        udpDetailsPage.customReportInfo.downloadCustomReportButton.isPresent
-      ).to.equal(true);
-      expect(
-        udpDetailsPage.customReportInfo.deleteCustomReportButton.isPresent
-      ).to.equal(true);
-    });
-
-    describe('delete custom report', function() {
-      beforeEach(async function() {
-        await udpDetailsPage.customReportInfo.deleteCustomReportButton.click();
-        await udpDetailsPage.confirmDeleteButton.click();
+    let initialCustomReports = null;
+    describe('custom reports are listed', function () {
+      beforeEach(async function () {
+        await udpDetailsPage.statisticsAccordion.click();
+        await udpDetailsPage.clickCustomReportAccordion();
+        await udpDetailsPage.clickExpandAllCustomReportYears();
+        initialCustomReports = udpDetailsPage.customReports.instances().length;
       });
 
       it('renders custom reports', () => {
-        expect(udpDetailsPage.customReports.instances().length).to.equal(
-          initialCustomReports - 1
-        );
-      });
-    });
-  });
-
-  describe('can open upload counter report', function() {
-    beforeEach(async function() {
-      await udpDetailsPage.uploadAccordion.click();
-      await udpDetailsPage.clickUploadCounterButton();
-    });
-
-    it('renders upload counter report modal', () => {
-      expect(udpDetailsPage.uploadCounterModal.isPresent).to.equal(true);
-    });
-
-    it('does not render upload non-counter report modal', () => {
-      expect(udpDetailsPage.uploadNonCounterModal.isPresent).to.equal(false);
-    });
-
-    it('does render upload file button', () => {
-      expect(
-        udpDetailsPage.uploadCounterModal.uploadFileButton.isPresent
-      ).to.equal(true);
-    });
-  });
-
-  describe('can open upload non-counter report', function() {
-    beforeEach(async function() {
-      await udpDetailsPage.uploadAccordion.click();
-      await udpDetailsPage.clickUploadNonCounterButton();
-    });
-
-    it('does not render upload counter report modal', () => {
-      expect(udpDetailsPage.uploadCounterModal.isPresent).to.equal(false);
-    });
-
-    it('renders upload non-counter report modal', () => {
-      expect(udpDetailsPage.uploadNonCounterModal.isPresent).to.equal(true);
-    });
-
-    it('does render upload file button', () => {
-      expect(
-        udpDetailsPage.uploadNonCounterModal.uploadFileButton.isPresent
-      ).to.equal(true);
-    });
-
-    it('does render year input', () => {
-      expect(udpDetailsPage.uploadNonCounterModal.yearInput.isPresent).to.equal(
-        true
-      );
-    });
-
-    describe('handling drop file', () => {
-      beforeEach(async () => {
-        await udpDetailsPage.fileUploaderInteractor.drop();
-      });
-
-      it('calls onDrop and renders uploaded file', () => {
-        expect(udpDetailsPage.downloadFileButton.isPresent).to.equal(true);
+        expect(udpDetailsPage.customReports.instances().length).to.be.gte(1);
       });
     });
 
-    it('does not render link url text field', () => {
-      expect(
-        udpDetailsPage.uploadNonCounterModal.linkUrlInput.isPresent
-      ).to.equal(false);
-    });
-
-    describe('click link file', function() {
-      beforeEach(async function() {
-        await udpDetailsPage.uploadNonCounterModal.linkRadioButton.click();
+    describe('custom reports can be selected', function () {
+      beforeEach(async function () {
+        await udpDetailsPage.statisticsAccordion.click();
+        await udpDetailsPage.clickCustomReportAccordion();
+        await udpDetailsPage.clickExpandAllCustomReportYears();
+        await udpDetailsPage.customReports.clickFirstRow();
       });
 
-      it('does not render upload file button', () => {
+      it('renders custom report details', () => {
         expect(
-          udpDetailsPage.uploadNonCounterModal.uploadFileButton.isPresent
-        ).to.equal(false);
+          udpDetailsPage.customReportInfo.downloadCustomReportButton.isPresent
+        ).to.equal(true);
+        expect(
+          udpDetailsPage.customReportInfo.deleteCustomReportButton.isPresent
+        ).to.equal(true);
       });
 
-      it('does render link url text field', () => {
+      describe('delete custom report', function () {
+        beforeEach(async function () {
+          await udpDetailsPage.customReportInfo.deleteCustomReportButton.click();
+          await udpDetailsPage.confirmDeleteButton.click();
+        });
+
+        it('renders custom reports', () => {
+          expect(udpDetailsPage.customReports.instances().length).to.equal(
+            initialCustomReports - 1
+          );
+        });
+      });
+    });
+
+    describe('can open upload counter report', function () {
+      beforeEach(async function () {
+        await udpDetailsPage.uploadAccordion.click();
+        await udpDetailsPage.clickUploadCounterButton();
+      });
+
+      it('renders upload counter report modal', () => {
+        expect(udpDetailsPage.uploadCounterModal.isPresent).to.equal(true);
+      });
+
+      it('does not render upload non-counter report modal', () => {
+        expect(udpDetailsPage.uploadNonCounterModal.isPresent).to.equal(false);
+      });
+
+      it('does render upload file button', () => {
         expect(
-          udpDetailsPage.uploadNonCounterModal.linkUrlInput.isPresent
+          udpDetailsPage.uploadCounterModal.uploadFileButton.isPresent
         ).to.equal(true);
       });
     });
+
+    describe('can open upload non-counter report', function () {
+      beforeEach(async function () {
+        await udpDetailsPage.uploadAccordion.click();
+        await udpDetailsPage.clickUploadNonCounterButton();
+      });
+
+      it('does not render upload counter report modal', () => {
+        expect(udpDetailsPage.uploadCounterModal.isPresent).to.equal(false);
+      });
+
+      it('renders upload non-counter report modal', () => {
+        expect(udpDetailsPage.uploadNonCounterModal.isPresent).to.equal(true);
+      });
+
+      it('does render upload file button', () => {
+        expect(
+          udpDetailsPage.uploadNonCounterModal.uploadFileButton.isPresent
+        ).to.equal(true);
+      });
+
+      it('does render year input', () => {
+        expect(
+          udpDetailsPage.uploadNonCounterModal.yearInput.isPresent
+        ).to.equal(true);
+      });
+
+      describe('handling drop file', () => {
+        beforeEach(async () => {
+          await udpDetailsPage.fileUploaderInteractor.drop();
+        });
+
+        it('calls onDrop and renders uploaded file', () => {
+          expect(udpDetailsPage.downloadFileButton.isPresent).to.equal(true);
+        });
+      });
+
+      it('does not render link url text field', () => {
+        expect(
+          udpDetailsPage.uploadNonCounterModal.linkUrlInput.isPresent
+        ).to.equal(false);
+      });
+
+      describe('click link file', function () {
+        beforeEach(async function () {
+          await udpDetailsPage.uploadNonCounterModal.linkRadioButton.click();
+        });
+
+        it('does not render upload file button', () => {
+          expect(
+            udpDetailsPage.uploadNonCounterModal.uploadFileButton.isPresent
+          ).to.equal(false);
+        });
+
+        it('does render link url text field', () => {
+          expect(
+            udpDetailsPage.uploadNonCounterModal.linkUrlInput.isPresent
+          ).to.equal(true);
+        });
+
+        describe('enter invalid link url', function () {
+          beforeEach(async function () {
+            await udpDetailsPage.uploadNonCounterModal.linkUrlInput.fill(
+              'internet.com'
+            );
+          });
+
+          it('does render error', () => {
+            expect(udpDetailsPage.urlInputError.feedbackError).to.equal(
+              'Invalid URL: http:// or https:// required!'
+            );
+          });
+        });
+      });
+    });
   });
-});
+}); //
 
 describe('UDPDetailsPage by ID', () => {
   setupApplication();
   const udpDetailsPage = new UDPDetailsPage();
 
   let udp = null;
-  beforeEach(async function() {
+  beforeEach(async function () {
     udp = this.server.create('usage-data-provider', 'withUsageReports');
     this.visit(`/eusage/view/${udp.id}`);
   });
 
-  it('displays udp label in the pane header', function() {
+  it('displays udp label in the pane header', function () {
     expect(udpDetailsPage.title).to.include(udp.label);
   }).timeout(6000);
 });
@@ -355,17 +369,17 @@ describe('Inactive UDP disabled start harvester', () => {
   const udpDetailsPage = new UDPDetailsPage();
 
   let udp = null;
-  beforeEach(async function() {
+  beforeEach(async function () {
     udp = this.server.create('usage-data-provider', 'withSetInactive');
     this.visit(`/eusage/view/${udp.id}`);
   });
 
-  it('harvesting config accordion is present', function() {
+  it('harvesting config accordion is present', function () {
     expect(udpDetailsPage.harvestingAccordion.isPresent).to.equal(true);
   });
 
-  describe('open harvesting accordion and check if start harvesting button is disabled', function() {
-    beforeEach(async function() {
+  describe('open harvesting accordion and check if start harvesting button is disabled', function () {
+    beforeEach(async function () {
       await udpDetailsPage.harvestingAccordionButton.click();
     });
 
@@ -381,17 +395,17 @@ describe('Active UDP enabled start harvester', () => {
   const udpDetailsPage = new UDPDetailsPage();
 
   let udp = null;
-  beforeEach(async function() {
+  beforeEach(async function () {
     udp = this.server.create('usage-data-provider');
     this.visit(`/eusage/view/${udp.id}`);
   });
 
-  it('harvesting config accordion is present', function() {
+  it('harvesting config accordion is present', function () {
     expect(udpDetailsPage.harvestingAccordion.isPresent).to.equal(true);
   });
 
-  describe('open harvesting accordion and check if start harvesting button is enabled', function() {
-    beforeEach(async function() {
+  describe('open harvesting accordion and check if start harvesting button is enabled', function () {
+    beforeEach(async function () {
       await udpDetailsPage.harvestingAccordionButton.click();
     });
 
@@ -408,13 +422,13 @@ describe('Renders custom reports with link correctly', () => {
 
   let udp = null;
   let initialCustomReports = null;
-  beforeEach(async function() {
+  beforeEach(async function () {
     udp = this.server.create('usage-data-provider', 'withCustomReportsLinks');
     await this.visit(`/eusage/${udp.id}`);
   });
 
-  describe('custom reports are listed', function() {
-    beforeEach(async function() {
+  describe('custom reports are listed', function () {
+    beforeEach(async function () {
       await udpDetailsPage.statisticsAccordion.click();
       await udpDetailsPage.clickCustomReportAccordion();
       await udpDetailsPage.clickExpandAllCustomReportYears();
@@ -425,8 +439,8 @@ describe('Renders custom reports with link correctly', () => {
       expect(udpDetailsPage.customReports.instances().length).to.be.gte(1);
     });
 
-    describe('custom reports can be selected', function() {
-      beforeEach(async function() {
+    describe('custom reports can be selected', function () {
+      beforeEach(async function () {
         await udpDetailsPage.statisticsAccordion.click();
         await udpDetailsPage.clickCustomReportAccordion();
         await udpDetailsPage.clickExpandAllCustomReportYears();
@@ -451,8 +465,8 @@ describe('Renders custom reports with link correctly', () => {
         ).to.equal(true);
       });
 
-      describe('delete custom report', function() {
-        beforeEach(async function() {
+      describe('delete custom report', function () {
+        beforeEach(async function () {
           await udpDetailsPage.customReportInfo.deleteCustomReportButton.click();
           await udpDetailsPage.confirmDeleteButton.click();
         });

--- a/test/bigtest/tests/details-udp-test.js
+++ b/test/bigtest/tests/details-udp-test.js
@@ -283,6 +283,30 @@ describe('UDPDetailsPage', () => {
         true
       );
     });
+
+    it('does not render link url text field', () => {
+      expect(
+        udpDetailsPage.uploadNonCounterModal.linkUrlInput.isPresent
+      ).to.equal(false);
+    });
+
+    describe('click link file', function () {
+      beforeEach(async function () {
+        await udpDetailsPage.uploadNonCounterModal.linkRadioButton.click();
+      });
+
+      it('does not render upload file button', () => {
+        expect(
+          udpDetailsPage.uploadNonCounterModal.uploadFileButton.isPresent
+        ).to.equal(false);
+      });
+
+      it('does render link url text field', () => {
+        expect(
+          udpDetailsPage.uploadNonCounterModal.linkUrlInput.isPresent
+        ).to.equal(true);
+      });
+    });
   });
 });
 

--- a/test/bigtest/tests/details-udp-test.js
+++ b/test/bigtest/tests/details-udp-test.js
@@ -207,11 +207,13 @@ describe('UDPDetailsPage', () => {
     });
   });
 
+  let initialCustomReports = null;
   describe('custom reports are listed', function() {
     beforeEach(async function() {
       await udpDetailsPage.statisticsAccordion.click();
       await udpDetailsPage.clickCustomReportAccordion();
       await udpDetailsPage.clickExpandAllCustomReportYears();
+      initialCustomReports = udpDetailsPage.customReports.instances().length;
     });
 
     it('renders custom reports', () => {
@@ -234,6 +236,19 @@ describe('UDPDetailsPage', () => {
       expect(
         udpDetailsPage.customReportInfo.deleteCustomReportButton.isPresent
       ).to.equal(true);
+    });
+
+    describe('delete custom report', function() {
+      beforeEach(async function() {
+        await udpDetailsPage.customReportInfo.deleteCustomReportButton.click();
+        await udpDetailsPage.confirmDeleteButton.click();
+      });
+
+      it('renders custom reports', () => {
+        expect(udpDetailsPage.customReports.instances().length).to.equal(
+          initialCustomReports - 1
+        );
+      });
     });
   });
 
@@ -382,6 +397,7 @@ describe('Renders custom reports with link correctly', () => {
   const udpInteractor = new UDPInteractor();
 
   let udp = null;
+  let initialCustomReports = null;
   beforeEach(async function() {
     udp = this.server.create('usage-data-provider', 'withCustomReportsLinks');
     await this.visit(`/eusage/${udp.id}`);
@@ -392,6 +408,7 @@ describe('Renders custom reports with link correctly', () => {
       await udpDetailsPage.statisticsAccordion.click();
       await udpDetailsPage.clickCustomReportAccordion();
       await udpDetailsPage.clickExpandAllCustomReportYears();
+      initialCustomReports = udpDetailsPage.customReports.instances().length;
     });
 
     it('renders custom reports', () => {
@@ -422,6 +439,19 @@ describe('Renders custom reports with link correctly', () => {
         expect(
           udpDetailsPage.customReportInfo.deleteCustomReportButton.isPresent
         ).to.equal(true);
+      });
+
+      describe('delete custom report', function() {
+        beforeEach(async function() {
+          await udpDetailsPage.customReportInfo.deleteCustomReportButton.click();
+          await udpDetailsPage.confirmDeleteButton.click();
+        });
+
+        it('renders custom reports', () => {
+          expect(udpDetailsPage.customReports.instances().length).to.equal(
+            initialCustomReports - 1
+          );
+        });
       });
     });
   });

--- a/test/bigtest/tests/details-udp-test.js
+++ b/test/bigtest/tests/details-udp-test.js
@@ -10,7 +10,7 @@ describe('UDPDetailsPage', () => {
   const udpInteractor = new UDPInteractor();
 
   let udp = null;
-  beforeEach(async function () {
+  beforeEach(async function() {
     udp = this.server.create('usage-data-provider', 'withUsageReports');
     await this.visit('/eusage/?filters=harvestingStatus.active');
   });
@@ -23,24 +23,24 @@ describe('UDPDetailsPage', () => {
     expect(udpInteractor.instances().length).to.be.gte(1);
   });
 
-  describe('clicking on the first item', function () {
-    beforeEach(async function () {
+  describe('clicking on the first item', function() {
+    beforeEach(async function() {
       await udpInteractor.instances(0).click();
     });
 
-    it('displays udp label in the pane header', function () {
+    it('displays udp label in the pane header', function() {
       expect(udpDetailsPage.title).to.include(udp.label);
     });
 
-    it('all accordions are present', function () {
+    it('all accordions are present', function() {
       expect(udpDetailsPage.harvestingAccordion.isPresent).to.equal(true);
       expect(udpDetailsPage.sushiCredentialsAccordion.isPresent).to.equal(true);
       expect(udpDetailsPage.statisticsAccordion.isPresent).to.equal(true);
       expect(udpDetailsPage.uploadAccordion.isPresent).to.equal(true);
     });
 
-    describe('all accordions can be expanded', function () {
-      beforeEach(async function () {
+    describe('all accordions can be expanded', function() {
+      beforeEach(async function() {
         await udpDetailsPage.expandAll.click();
       });
 
@@ -50,8 +50,8 @@ describe('UDPDetailsPage', () => {
         );
       });
 
-      describe('all accordions can be collapsed', function () {
-        beforeEach(async function () {
+      describe('all accordions can be collapsed', function() {
+        beforeEach(async function() {
           await udpDetailsPage.expandAll.click();
         });
 
@@ -63,8 +63,8 @@ describe('UDPDetailsPage', () => {
       });
     });
 
-    describe('service type is set correctly', function () {
-      beforeEach(async function () {
+    describe('service type is set correctly', function() {
+      beforeEach(async function() {
         await udpDetailsPage.harvestingAccordion.click();
       });
 
@@ -77,8 +77,8 @@ describe('UDPDetailsPage', () => {
       });
     });
 
-    describe('can select report type for download multi months', function () {
-      beforeEach(async function () {
+    describe('can select report type for download multi months', function() {
+      beforeEach(async function() {
         await udpDetailsPage.statisticsAccordion.click();
       });
 
@@ -160,12 +160,12 @@ describe('UDPDetailsPage', () => {
     });
 
     describe('can open report info menu', () => {
-      beforeEach(async function () {
+      beforeEach(async function() {
         await udpDetailsPage.statisticsAccordion.click();
       });
 
       describe('valid report has correct buttons', () => {
-        beforeEach(async function () {
+        beforeEach(async function() {
           await udpDetailsPage.validReport();
         });
 
@@ -180,7 +180,7 @@ describe('UDPDetailsPage', () => {
       });
 
       describe('failed report has correct buttons', () => {
-        beforeEach(async function () {
+        beforeEach(async function() {
           await udpDetailsPage.failedReport();
         });
 
@@ -195,7 +195,7 @@ describe('UDPDetailsPage', () => {
       });
 
       describe('can open tags helper app', () => {
-        beforeEach(async function () {
+        beforeEach(async function() {
           await udpDetailsPage.clickShowTags();
           await udpDetailsPage.tagsSelect.clickable();
         });
@@ -207,8 +207,8 @@ describe('UDPDetailsPage', () => {
     });
   });
 
-  describe('custom reports are listed', function () {
-    beforeEach(async function () {
+  describe('custom reports are listed', function() {
+    beforeEach(async function() {
       await udpDetailsPage.statisticsAccordion.click();
       await udpDetailsPage.clickCustomReportAccordion();
       await udpDetailsPage.clickExpandAllCustomReportYears();
@@ -219,8 +219,8 @@ describe('UDPDetailsPage', () => {
     });
   });
 
-  describe('custom reports can be selected', function () {
-    beforeEach(async function () {
+  describe('custom reports can be selected', function() {
+    beforeEach(async function() {
       await udpDetailsPage.statisticsAccordion.click();
       await udpDetailsPage.clickCustomReportAccordion();
       await udpDetailsPage.clickExpandAllCustomReportYears();
@@ -237,8 +237,8 @@ describe('UDPDetailsPage', () => {
     });
   });
 
-  describe('can open upload counter report', function () {
-    beforeEach(async function () {
+  describe('can open upload counter report', function() {
+    beforeEach(async function() {
       await udpDetailsPage.uploadAccordion.click();
       await udpDetailsPage.clickUploadCounterButton();
     });
@@ -258,8 +258,8 @@ describe('UDPDetailsPage', () => {
     });
   });
 
-  describe('can open upload non-counter report', function () {
-    beforeEach(async function () {
+  describe('can open upload non-counter report', function() {
+    beforeEach(async function() {
       await udpDetailsPage.uploadAccordion.click();
       await udpDetailsPage.clickUploadNonCounterButton();
     });
@@ -290,8 +290,8 @@ describe('UDPDetailsPage', () => {
       ).to.equal(false);
     });
 
-    describe('click link file', function () {
-      beforeEach(async function () {
+    describe('click link file', function() {
+      beforeEach(async function() {
         await udpDetailsPage.uploadNonCounterModal.linkRadioButton.click();
       });
 
@@ -315,12 +315,12 @@ describe('UDPDetailsPage by ID', () => {
   const udpDetailsPage = new UDPDetailsPage();
 
   let udp = null;
-  beforeEach(async function () {
+  beforeEach(async function() {
     udp = this.server.create('usage-data-provider', 'withUsageReports');
     this.visit(`/eusage/view/${udp.id}`);
   });
 
-  it('displays udp label in the pane header', function () {
+  it('displays udp label in the pane header', function() {
     expect(udpDetailsPage.title).to.include(udp.label);
   }).timeout(6000);
 });
@@ -330,17 +330,17 @@ describe('Inactive UDP disabled start harvester', () => {
   const udpDetailsPage = new UDPDetailsPage();
 
   let udp = null;
-  beforeEach(async function () {
+  beforeEach(async function() {
     udp = this.server.create('usage-data-provider', 'withSetInactive');
     this.visit(`/eusage/view/${udp.id}`);
   });
 
-  it('harvesting config accordion is present', function () {
+  it('harvesting config accordion is present', function() {
     expect(udpDetailsPage.harvestingAccordion.isPresent).to.equal(true);
   });
 
-  describe('open harvesting accordion and check if start harvesting button is disabled', function () {
-    beforeEach(async function () {
+  describe('open harvesting accordion and check if start harvesting button is disabled', function() {
+    beforeEach(async function() {
       await udpDetailsPage.harvestingAccordionButton.click();
     });
 
@@ -356,22 +356,73 @@ describe('Active UDP enabled start harvester', () => {
   const udpDetailsPage = new UDPDetailsPage();
 
   let udp = null;
-  beforeEach(async function () {
+  beforeEach(async function() {
     udp = this.server.create('usage-data-provider');
     this.visit(`/eusage/view/${udp.id}`);
   });
 
-  it('harvesting config accordion is present', function () {
+  it('harvesting config accordion is present', function() {
     expect(udpDetailsPage.harvestingAccordion.isPresent).to.equal(true);
   });
 
-  describe('open harvesting accordion and check if start harvesting button is enabled', function () {
-    beforeEach(async function () {
+  describe('open harvesting accordion and check if start harvesting button is enabled', function() {
+    beforeEach(async function() {
       await udpDetailsPage.harvestingAccordionButton.click();
     });
 
     it('start harvesting button is present and enabled', () => {
       expect(udpDetailsPage.startHarvesterButton.isPresent).to.equal(true);
+    });
+  });
+});
+
+describe('Renders custom reports with link correctly', () => {
+  setupApplication();
+  const udpDetailsPage = new UDPDetailsPage();
+  const udpInteractor = new UDPInteractor();
+
+  let udp = null;
+  beforeEach(async function() {
+    udp = this.server.create('usage-data-provider', 'withCustomReportsLinks');
+    await this.visit(`/eusage/${udp.id}`);
+  });
+
+  describe('custom reports are listed', function() {
+    beforeEach(async function() {
+      await udpDetailsPage.statisticsAccordion.click();
+      await udpDetailsPage.clickCustomReportAccordion();
+      await udpDetailsPage.clickExpandAllCustomReportYears();
+    });
+
+    it('renders custom reports', () => {
+      expect(udpDetailsPage.customReports.instances().length).to.be.gte(1);
+    });
+
+    describe('custom reports can be selected', function() {
+      beforeEach(async function() {
+        await udpDetailsPage.statisticsAccordion.click();
+        await udpDetailsPage.clickCustomReportAccordion();
+        await udpDetailsPage.clickExpandAllCustomReportYears();
+        await udpDetailsPage.customReports.clickFirstRow();
+      });
+
+      it('does not render download custom report button', () => {
+        expect(
+          udpDetailsPage.customReportInfo.downloadCustomReportButton.isPresent
+        ).to.equal(false);
+      });
+
+      it('does render link to custom report', () => {
+        expect(
+          udpDetailsPage.customReportInfo.customReportLink.isPresent
+        ).to.equal(true);
+      });
+
+      it('does render delete custom report button', () => {
+        expect(
+          udpDetailsPage.customReportInfo.deleteCustomReportButton.isPresent
+        ).to.equal(true);
+      });
     });
   });
 });

--- a/test/bigtest/tests/details-udp-test.js
+++ b/test/bigtest/tests/details-udp-test.js
@@ -299,6 +299,16 @@ describe('UDPDetailsPage', () => {
       );
     });
 
+    describe('handling drop file', () => {
+      beforeEach(async () => {
+        await udpDetailsPage.fileUploaderInteractor.drop();
+      });
+
+      it('calls onDrop and renders uploaded file', () => {
+        expect(udpDetailsPage.downloadFileButton.isPresent).to.equal(true);
+      });
+    });
+
     it('does not render link url text field', () => {
       expect(
         udpDetailsPage.uploadNonCounterModal.linkUrlInput.isPresent

--- a/translations/ui-erm-usage/en.json
+++ b/translations/ui-erm-usage/en.json
@@ -11,6 +11,7 @@
 
   "meta.title": "eUsage",
 
+  "general.cancel": "Cancel",
   "general.delete": "Delete",
   "general.save": "Save",
   "general.info": "Info",
@@ -185,6 +186,7 @@
   "errors.emailInvalid": "Email address invalid",
   "errors.dateInvalid": "Date invalid",
   "errors.endDateMustBeGraterStartDate": "End date must be greater than start date",
+  "errors.urlRequired": "Invalid URL: http:// or https:// required!",
 
   "harvester.start": "Start harvester",
   "harvester.start.started": "Harvester started",
@@ -227,6 +229,11 @@
   "statistics.custom.info.detail": "Detail info",
   "statistics.custom.selectFileFirst": "Select file first",
   "statistics.custom.selectedFile": "Selected file",
+  "statistics.custom.selectFileUpload": "Select file to upload",
+  "statistics.custom.linkUrl": "Link URL",
+  "statistics.custom.uploadFile": "Upload file",
+  "statistics.custom.linkFile": "Link file",
+  "statistics.custom.delete": "Delete custom report",
 
   "permission.module.enabled": "UI: eUsage module is enabled",
   "permission.generalSettings.manage": "Settings (eUsage): Can view and edit settings",

--- a/translations/ui-erm-usage/en.json
+++ b/translations/ui-erm-usage/en.json
@@ -116,6 +116,7 @@
   "report.upload.dropFile": "Drop file here",
   "report.upload.selectFile": "or select file",
   "report.upload.info": "It is possible to upload Counter 4 (XML & CSV) or Counter 5 (JSON & CSV) usage statistics",
+  "report.delete.failed": "Failed...",
 
   "report.error.other": "Other",
   "report.error.0": "Info or debug",

--- a/translations/ui-erm-usage/en.json
+++ b/translations/ui-erm-usage/en.json
@@ -84,7 +84,8 @@
   "reportOverview.month.12": "Dec",
   "reportOverview.report": "Report",
 
-  "reportOverview.confirmDelete": "Please confirm delete!",
+  "reportOverview.confirmDelete": "Delete non-counter report?",
+  "reportOverview.deleteTemplateMessage": "{name} will be removed from non-counter reports.",
   "reportOverview.reportType": "Report type",
   "reportOverview.reportDate": "Report date",
   "reportOverview.reportsPerYear": "Reports grouped by year",


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/UIEUS-227

## What?
Added support to reference a non-counter report via a link.

## Why?
Users would like to be able to not upload a non-counter file directly to the system, but store a link to an external storage instead (file system, FTP or cloud, e.g. Box).

## How?
This PR adds support to either upload a file as a non-counter report (as before) or specify a link url which references the non-counter file.