### PR TITLE
UIEUS-230: Fix typo in subPerm of settings perm

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "permissionName": "ui-erm-usage.generalSettings.manage",
         "displayName": "Settings (eUsage): Can view and edit settings",
         "subPermissions": [
-          "settings.erm-usage.enable"
+          "settings.erm-usage.enabled"
         ],
         "visible": true
       },


### PR DESCRIPTION
This PR fixes the bug that granting the permission "Settings (eUsage): Can view and edit settings" does not enable settings.

Refs. https://issues.folio.org/browse/UIEUS-230