### PR TITLE
UIEUS-254: Bugfix create udp with aggregator

### DIFF
--- a/src/components/HarvestingConfiguration/SelectedReports/SelectedReportsForm.js
+++ b/src/components/HarvestingConfiguration/SelectedReports/SelectedReportsForm.js
@@ -70,12 +70,16 @@ class SelectedReportsForm extends React.Component {
       index
     );
     return (
-      <Field
-        component={Selection}
-        dataOptions={list}
-        label={<FormattedMessage id="ui-erm-usage.reportOverview.reportType" />}
-        name={field}
-      />
+      <div id={`reportType-selection-${index}`}>
+        <Field
+          component={Selection}
+          dataOptions={list}
+          label={
+            <FormattedMessage id="ui-erm-usage.reportOverview.reportType" />
+          }
+          name={field}
+        />
+      </div>
     );
   }
 

--- a/src/components/HarvestingConfiguration/VendorInfo/VendorInfoForm.js
+++ b/src/components/HarvestingConfiguration/VendorInfo/VendorInfoForm.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Field } from 'react-final-form';
 import { Col, Select, TextField } from '@folio/stripes/components';
-import { notRequired, required, requiredValidateUrl } from '../../../util/validate';
+import {
+  notRequired,
+  required,
+  requiredValidateUrl,
+} from '../../../util/validate';
 
 class VendorInfoForm extends React.Component {
   static propTypes = {
@@ -22,6 +26,14 @@ class VendorInfoForm extends React.Component {
       this.isRequired = this.props.disabled ? notRequired : required;
     }
   }
+
+  validateUrl = (url) => {
+    const { disabled } = this.props;
+    if (disabled) {
+      return undefined;
+    }
+    return requiredValidateUrl(url);
+  };
 
   render() {
     const { disabled, harvesterImpls, intl } = this.props;
@@ -57,7 +69,7 @@ class VendorInfoForm extends React.Component {
             component={TextField}
             disabled={disabled}
             required={!disabled}
-            validate={requiredValidateUrl}
+            validate={(val) => this.validateUrl(val)}
             fullWidth
           />
         </Col>

--- a/test/bigtest/interactors/udp-edit-page.js
+++ b/test/bigtest/interactors/udp-edit-page.js
@@ -2,10 +2,14 @@ import {
   attribute,
   clickable,
   interactor,
+  is,
   isPresent,
+  scoped,
   text,
   value,
 } from '@bigtest/interactor';
+
+import SelectionInteractor from '@folio/stripes-components/lib/Selection/tests/interactor'; // eslint-disable-line
 
 @interactor class HarvestingStatusSelect {
   static defaultScope = 'select[name="harvestingConfig.harvestingStatus"]';
@@ -17,13 +21,19 @@ import {
   value = value();
 }
 
+@interactor class AggregatorSelect {
+  static defaultScope = 'select[name="harvestingConfig.aggregator.id"]';
+  value = value();
+}
+
 @interactor class ReportReleaseSelect {
   static defaultScope = 'select[id="addudp_reportrelease"]';
   value = value();
 }
 
 @interactor class ReportTypeSelect {
-  static defaultScope = 'select[id=""]';
+  static defaultScope = 'select[name="harvestingConfig.requestedReports[0]"]';
+  value = value();
 }
 
 @interactor class DeleteUDPConfirmation {
@@ -57,13 +67,19 @@ export default @interactor class UDPEditPage {
   title = text('[class*=paneTitleLabel---]');
   harvestingStatusSelect = new HarvestingStatusSelect();
   harvestingViaSelect = new HarvestingViaSelect();
+  aggregatorSelect = new AggregatorSelect();
   deleteUDPConfirmation = new DeleteUDPConfirmation();
 
   clickDeleteUDP = clickable('#clickable-delete-udp');
 
+  reportTypeSelection = new SelectionInteractor('#reportType-selection-0');
+
   reportReleaseSelect = new ReportReleaseSelect();
   reportTypeSelect = new ReportTypeSelect();
   clickAddReportButton = clickable('[data-test-repeatable-field-add-item-button]');
+  harvestingStart = scoped('#input-harvestingStart');
+  providerName = scoped('#addudp_providername');
+  saveButtonIsDisabled = is('[data-test-udp-form-submit-button]', ':disabled');
   confirmationModal = new ConfirmationModal();
 
   customerId = new CustomerId();

--- a/test/bigtest/tests/create-udp-test.js
+++ b/test/bigtest/tests/create-udp-test.js
@@ -14,6 +14,7 @@ describe('Create UDP', () => {
   const udpEditPage = new UDPEditPage();
 
   beforeEach(function () {
+    this.server.createList('aggregator-setting', 3);
     return this.visit(
       '/eusage/create?filters=harvestingStatus.active&sort=label',
       () => {
@@ -111,6 +112,22 @@ describe('Create UDP', () => {
       it('customer id is mandatory', () => {
         expect(udpEditPage.customerId.required).to.not.be.null;
       });
+    });
+  });
+
+  describe('harvest via aggregator happy path', () => {
+    beforeEach(async () => {
+      await udpEditPage.providerName.fill('Provier 1');
+      await udpEditPage.harvestingStatusSelect.select('Active');
+      await udpEditPage.harvestingViaSelect.select('Aggregator');
+      await udpEditPage.aggregatorSelect.select('Aggregator 1');
+      await udpEditPage.reportReleaseSelect.select('Counter 4');
+      await udpEditPage.clickAddReportButton();
+      await udpEditPage.reportTypeSelection.expandAndClick(1);
+      await udpEditPage.harvestingStart.fill('2020-01');
+    });
+    it('Save & close button is enabled', () => {
+      expect(udpEditPage.saveButtonIsDisabled).to.be.false;
     });
   });
 });


### PR DESCRIPTION
This PR fixes the bug that it was not possible to create a new UDP that fetches statistics via an aggregator.
If fetching via SUSHI, the vendor's URL is validated. However, validation happened always. When configuring a UDP to harvest via an aggregator, the vendor's URL may be null, and thus the validation failed. Hence, the form was invalid and the user was not able to save.
This PR checks if the vendor's URL need to be validated before doing the validation.

Refs. https://issues.folio.org/browse/UIEUS-254