### PR TITLE
Fix propypes-checking error

### DIFF
--- a/src/components/views/UDP.js
+++ b/src/components/views/UDP.js
@@ -153,7 +153,7 @@ class UDP extends React.Component {
                   this.showHelperApp('tags');
                 }}
                 badgeCount={tags.length}
-                ariaLabel={ariaLabel}
+                ariaLabel={typeof ariaLabel === 'string' ? ariaLabel : ariaLabel[0]}
               />
             )}
           </FormattedMessage>


### PR DESCRIPTION
It seems that the functional-children form of `<FormattedMessage>`
sometimes returns a one-element array of strings rather than the
expected single string. Passing this element as the `ariaLabel` of a
`<PaneHeaderIconButton>` results in a big, ugly, red console message.

We fix this by checking whether the label is a simple string: if so we
use it as-is, otherwise we assume it's an array and use its first
element.