### PR TITLE
UIEUS-329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-erm-usage
 
 ## 7.1.0 (IN PROGRESS)
+* Set initialValue for periodic interval field in periodic harvesting settings ([UIEUS-329](https://issues.folio.org/browse/UIEUS-329))
 * Add settings page for harvester logs ([UIEUS-330](https://issues.folio.org/browse/UIEUS-330))
 * Add 'Running status' and 'Result' information to 'Harvester logs' view and filter ([UIEUS-304](https://issues.folio.org/browse/UIEUS-304))
 * Avoid private paths in stripes-core imports ([UIEUS-322](https://issues.folio.org/browse/UIEUS-322))

--- a/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.js
+++ b/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { IfPermission } from '@folio/stripes/core';
 import {
   Button,
@@ -25,6 +25,7 @@ class PeriodicHarvestingForm extends React.Component {
   static propTypes = {
     handleSubmit: PropTypes.func.isRequired,
     initialValues: PropTypes.shape(),
+    intl: PropTypes.object.isRequired,
     onDelete: PropTypes.func.isRequired,
     timeZone: PropTypes.string.isRequired,
   };
@@ -62,7 +63,7 @@ class PeriodicHarvestingForm extends React.Component {
   }
 
   render() {
-    const { handleSubmit, initialValues } = this.props;
+    const { handleSubmit, initialValues, intl: { formatMessage } } = this.props;
     const isConfigEmpty = _.isEmpty(initialValues);
     const lastTriggeredAt = initialValues.lastTriggeredAt
       ? moment(initialValues.lastTriggeredAt).format('LLL')
@@ -77,9 +78,9 @@ class PeriodicHarvestingForm extends React.Component {
                 label={
                   <FormattedMessage id="ui-erm-usage.settings.harvester.config.periodic.start.date" />
                 }
-                aria-label={
-                  <FormattedMessage id="ui-erm-usage.settings.harvester.config.periodic.start.date" />
-                }
+                aria-label={formatMessage({
+                  id: 'ui-erm-usage.settings.harvester.config.periodic.start.date',
+                })}
                 name="startDate"
                 id="periodic-harvesting-start"
                 component={Datepicker}
@@ -93,9 +94,9 @@ class PeriodicHarvestingForm extends React.Component {
             <Col xs={8}>
               <Field
                 name="startTime"
-                label={
-                  <FormattedMessage id="ui-erm-usage.settings.harvester.config.periodic.start.time" />
-                }
+                label={formatMessage({
+                  id: 'ui-erm-usage.settings.harvester.config.periodic.start.time',
+                })}
                 component={Timepicker}
                 autoComplete="off"
                 timeZone={this.props.timeZone}
@@ -181,4 +182,4 @@ export default stripesFinalForm({
     values: true,
     invalid: true,
   },
-})(PeriodicHarvestingForm);
+})(injectIntl(PeriodicHarvestingForm));

--- a/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.js
+++ b/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.js
@@ -113,6 +113,7 @@ class PeriodicHarvestingForm extends React.Component {
                 id="periodic-harvesting-interval"
                 component={Select}
                 dataOptions={periodicHarvestingIntervals}
+                initialValue={initialValues.periodicInterval || periodicHarvestingIntervals[0].value}
                 fullWidth
                 validate={required}
               />

--- a/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.test.js
+++ b/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.test.js
@@ -11,7 +11,7 @@ import periodicHarvestingIntervals from '../../util/data/periodicHarvestingInter
 
 const stubInitialValues = {
   startDate: '2021-01-01',
-  startTime: '2021-01-01T07:00:00+00:00',
+  startTime: '07:00 AM',
   periodicInterval: 'weekly',
 };
 

--- a/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.test.js
+++ b/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.test.js
@@ -7,6 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import renderWithIntl from '../../../test/jest/helpers';
 
 import PeriodicHarvestingForm from './PeriodicHarvestingForm';
+import periodicHarvestingIntervals from '../../util/data/periodicHarvestingIntervals';
 
 const stubInitialValues = {
   startDate: '2021-01-01',
@@ -44,10 +45,13 @@ describe('PeriodicHarvestingForm', () => {
     stripes = useStripes();
   });
 
-  test('test required fields', () => {
+  test('test required fields and combobox initial value', () => {
     renderPeriodicHarvestingForm(stripes);
     userEvent.click(screen.getByText('Save'));
-    expect(screen.getAllByText('Required')).toHaveLength(3);
+    expect(screen.getAllByText('Required')).toHaveLength(2);
+    expect(screen.getByRole('combobox').value).toBe(
+      periodicHarvestingIntervals[0].value
+    );
     expect(onSubmit).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Sets the initialValue on periodicInterval field so that the field is not marked as required when a user clicks save.
Also fixes some warnings that occured in test.