### PR TITLE
UIEUS-343 bump react-dropzone to v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix test warnings 'No metadata' ([UIEUS-320](https://issues.folio.org/browse/UIEUS-320))
 * Leverage cookie-based authentication in all API requests. Refs UIEUS-314.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs ([UIEUS-342](https://issues.folio.org/browse/UIEUS-342)).
+* Bump `react-dropzone` to `v10.2.2`. Refs ([UIEUS-343](https://issues.folio.org/browse/UIEUS-343)).
 
 ## [7.0.0](https://github.com/folio-org/ui-erm-usage/tree/v7.0.0) (2023-02-20)
 * Upgrade `react-redux` to v8 ([UIEUS-318](https://issues.folio.org/browse/UIEUS-318))

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",
     "prop-types": "^15.6.0",
-    "react-dropzone": "^9.0.0",
+    "react-dropzone": "^10.2.2",
     "react-final-form": "^6.3.5",
     "react-final-form-arrays": "^3.1.1",
     "react-router-prop-types": "^1.0.4",


### PR DESCRIPTION
Bump `react-dropzone` from `v9` to `v10`. It is still far out of date (current is `v14`) but the only breaking change in `v10` is dropping support for `react` `v16` so this seems like the smallest/safest change. `v11` and up contain more extensive changes that need to be carefully evaluated.

Refs [UIEUS-343](https://issues.folio.org/browse/UIEUS-343)