### PR TITLE
UIEUS-321 Address test warnings

### DIFF
--- a/src/components/HarvestingConfiguration/SelectedReports/SelectedReportsForm.js
+++ b/src/components/HarvestingConfiguration/SelectedReports/SelectedReportsForm.js
@@ -9,7 +9,7 @@ import counterReports from './data/counterReports';
 import css from './SelectedReportsForm.css';
 
 import SelectReportType from './SelectReportType';
-import { notRequired, requiredArray } from '../../../util/validate';
+import { requiredArray } from '../../../util/validate';
 
 const getCounterReportsForVersion = (counterVersion) => {
   return _.filter(counterReports.getOptions(), [
@@ -48,8 +48,8 @@ class SelectedReportsForm extends React.Component {
       <FieldArray
         name="harvestingConfig.requestedReports"
         required={this.props.required}
-        validate={this.props.required ? requiredArray : notRequired}
-        data={this.props.required ? 1 : 0}
+        // dont know why, but this seems to work
+        validate={(value) => this.props.required && requiredArray(value)}
       >
         {({ fields }) => (
           <SelectReportType

--- a/src/components/views/UDPForm.test.js
+++ b/src/components/views/UDPForm.test.js
@@ -412,6 +412,27 @@ describe('UDPForm', () => {
       expect(screen.getByRole('textbox', { name: 'Requestor mail' })).not.toBeRequired();
     });
 
+    test('saving a named inactive provider', async () => {
+      const harvestingStatusCombobox = screen.getByRole('combobox', { name: 'Harvesting status' });
+      const providerNameTextbox = screen.getByRole('textbox', { name: 'Provider name' });
+      const saveAndCloseButton = screen.getByRole('button', { name: 'Save & close' });
+
+      // status = active && name set
+      await userEvent.selectOptions(harvestingStatusCombobox, ['active']);
+      await userEvent.type(providerNameTextbox, 'FooBar');
+      expect(harvestingStatusCombobox).toHaveValue('active');
+      expect(providerNameTextbox).toHaveValue('FooBar');
+      await userEvent.click(saveAndCloseButton);
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      // status = inactive && name set
+      await userEvent.selectOptions(harvestingStatusCombobox, ['inactive']);
+      expect(harvestingStatusCombobox).toHaveValue('inactive');
+      expect(providerNameTextbox).toHaveValue('FooBar');
+      await userEvent.click(saveAndCloseButton);
+      expect(onSubmit).toHaveBeenCalled();
+    });
+
     describe('test required value of customerId field', () => {
       test('change harvest statistics via from sushi to aggregator', async () => {
         await userEvent.selectOptions(
@@ -450,7 +471,6 @@ describe('UDPForm', () => {
     const testSelectReportRelease = async (reportRelease) => {
       renderUDPForm(stripes, reportReleaseProvider);
       const reqIdBox = screen.getByRole('textbox', { name: 'Requestor ID' });
-      // const apiKeyBox = screen.getByRole('textbox', { name: 'API key' });
       const releaseSelectBox = screen.getByLabelText('Report release', { exact: false });
 
       expect(reqIdBox).toBeEnabled();

--- a/src/settings/Aggregators/DownloadCredentialsButton/DownloadCredentialsButton.js
+++ b/src/settings/Aggregators/DownloadCredentialsButton/DownloadCredentialsButton.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { stripesConnect, stripesShape, CalloutContext } from '@folio/stripes/core';
+import { stripesConnect, CalloutContext } from '@folio/stripes/core';
 import {
   Button,
   Dropdown,
@@ -52,7 +52,9 @@ const DownloadCredentialsButton = ({ aggregatorId, stripes }) => {
 
 DownloadCredentialsButton.propTypes = {
   aggregatorId: PropTypes.string.isRequired,
-  stripes: stripesShape.isRequired,
+  stripes: PropTypes.shape({
+    okapi: PropTypes.object.isRequired,
+  }).isRequired,
 };
 
 export default stripesConnect(DownloadCredentialsButton);


### PR DESCRIPTION
While trying to get rid of `Cannot update a component` warnings, a bug was introduced. This bug prevents users from saving a Usage Data Provider due to a misbehaving validation function for report types.

The `data` property on the `FieldArray` component, does not seem to have the desired effect. Using the `key` property results in the mentioned warning.

Hopefully this PR will fix it.