### PR TITLE
APPDESCRIP-28: update erm-usage/files interface id to be valid for Eureka platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for ui-erm-usage
 
-## 9.1.0 (IN PROGRESS)
+## 10.0.0 (IN PROGRESS)
 * Fix bug in JobView test ([UIEUS-360](https://folio-org.atlassian.net/browse/UIEUS-360))
 * React v19: refactor away from default props for functional components ([UIEUS-355](https://folio-org.atlassian.net/browse/UIEUS-355))
+* Use erm-usage-files interface id that is valid for Eureka platform ([APPDESCRIP-28](https://folio-org.atlassian.net/browse/APPDESCRIP-28))
 
 ## [9.0.0](https://github.com/folio-org/ui-erm-usage/tree/v9.0.0) (2024-04-17)
 * *BREAKING* Use `multipart/form-data` to upload COUNTER reports ([UIEUS-353](https://folio-org.atlassian.net/browse/UIEUS-353))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/erm-usage",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "eUsage Module",
   "main": "src/index.js",
   "repository": "folio-org/ui-erm-usage",
@@ -74,7 +74,7 @@
       "configuration": "2.0",
       "counter-reports": "3.2",
       "custom-reports": "1.0",
-      "erm-usage/files": "1.0",
+      "erm-usage-files": "1.0",
       "usage-data-providers": "2.8",
       "tags": "1.0",
       "erm-usage-harvester": "1.4"


### PR DESCRIPTION
[APPDESCRIP-28](https://folio-org.atlassian.net/browse/APPDESCRIP-28)

Related PR: https://github.com/folio-org/app-erm-usage/pull/1

Purpose: update erm-usage/files interface id to be valid for Eureka platform