### PR TITLE
[UIEUS-381] Add support for interface custom-reports 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Update `counter-reports` interface to 4.0 ([UIEUS-378](https://folio-org.atlassian.net/browse/UIEUS-378))
 * Adjust permissions and update `aggregator-settings` interface to 2.0 ([UIEUS-379](https://folio-org.atlassian.net/browse/UIEUS-379))
 * Adjust permissions and update to `interface erm-usage-harvester 2.0` ([UIEUS-380](https://folio-org.atlassian.net/browse/UIEUS-380))
+* Add support for interface `custom-reports 2.0` ([UIEUS-381](https://folio-org.atlassian.net/browse/UIEUS-381))
 
 ## [9.0.0](https://github.com/folio-org/ui-erm-usage/tree/v9.0.0) (2024-04-17)
 * *BREAKING* Use `multipart/form-data` to upload COUNTER reports ([UIEUS-353](https://folio-org.atlassian.net/browse/UIEUS-353))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Fix GitHub Actions workflow not running for tags ([FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086))
 * Update `counter-reports` interface to 4.0 ([UIEUS-378](https://folio-org.atlassian.net/browse/UIEUS-378))
 * Adjust permissions and update `aggregator-settings` interface to 2.0 ([UIEUS-379](https://folio-org.atlassian.net/browse/UIEUS-379))
-* Adjust permissions and update to `interface erm-usage-harvester 2.0` ([UIEUS-380](https://folio-org.atlassian.net/browse/UIEUS-380))
+* Adjust permissions and update to interface `erm-usage-harvester 2.0` ([UIEUS-380](https://folio-org.atlassian.net/browse/UIEUS-380))
 * Add support for interface `custom-reports 2.0` ([UIEUS-381](https://folio-org.atlassian.net/browse/UIEUS-381))
 
 ## [9.0.0](https://github.com/folio-org/ui-erm-usage/tree/v9.0.0) (2024-04-17)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "aggregator-settings": "2.0",
       "configuration": "2.0",
       "counter-reports": "4.0",
-      "custom-reports": "1.0",
+      "custom-reports": "1.0 2.0",
       "erm-usage-files": "1.0",
       "usage-data-providers": "3.0",
       "tags": "1.0",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-381

* Adds support for interface `custom-reports 2.0`

See https://github.com/folio-org/mod-erm-usage/pull/186