### PR TITLE
UIEUS-386: Use keywords search for UDPs search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-erm-usage
 
 ## 10.1.0 (IN PROGRESS)
+* Use keywords search for UDPs search, requires interface `usage-data-providers 3.1` ([UIEUS-386](https://folio-org.atlassian.net/browse/UIEUS-386))
 
 ## [10.0.0](https://github.com/folio-org/ui-erm-usage/tree/v10.0.0) (2024-10-29)
 * Fix bug in JobView test ([UIEUS-360](https://folio-org.atlassian.net/browse/UIEUS-360))

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "counter-reports": "4.0",
       "custom-reports": "1.0 2.0",
       "erm-usage-files": "1.0",
-      "usage-data-providers": "3.0",
+      "usage-data-providers": "3.1",
       "tags": "1.0",
       "erm-usage-harvester": "2.0"
     },

--- a/src/routes/UDPsRoute.js
+++ b/src/routes/UDPsRoute.js
@@ -28,7 +28,7 @@ class UDPsRoute extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
-            '(label="%{query.query}*" or harvestingConfig.aggregator.name="%{query.query}*")',
+            '(keywords all "%{query.query}*")',
             {
               label: 'label',
               harvestingStatus: 'harvestingConfig.harvestingStatus',


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-386

The /usage-data-providers API (interface usage-data-providers 3.1) has added the new keywords search:
https://folio-org.atlassian.net/browse/MODEUS-189

Use a CQL query like keywords all "foo*" to make use of it.