### PR TITLE
[UIEUS-359] Update supported R5.1 report types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Use keywords search for UDPs search, requires interface `usage-data-providers 3.1` ([UIEUS-386](https://folio-org.atlassian.net/browse/UIEUS-386))
 * Change of report type options within the multi-month COUNTER statistics download feature ([UIEUS-369] (https://folio-org.atlassian.net/browse/UIEUS-369))
 * File path support for non-COUNTER reports ([UIEUS-356](https://folio-org.atlassian.net/browse/UIEUS-356))
+* COUNTER 5.1 Support: Download stored COUNTER 5.1 reports as CSV and XSLX ([UIEUS-359](https://folio-org.atlassian.net/browse/UIEUS-359))
 
 ## [10.0.1](https://github.com/folio-org/ui-erm-usage/tree/v10.0.1) (2024-12-02)
 * Update translation for permission ([UIEUS-385](https://folio-org.atlassian.net/browse/UIEUS-385))

--- a/src/components/Counter/CounterStatistics.test.js
+++ b/src/components/Counter/CounterStatistics.test.js
@@ -196,8 +196,10 @@ describe('CounterStatistics', () => {
       'TR_J4 (5)',
       'TR (5.1)',
       'TR_B1 (5.1)',
+      'TR_B2 (5.1)',
       'TR_B3 (5.1)',
       'TR_J1 (5.1)',
+      'TR_J2 (5.1)',
       'TR_J3 (5.1)',
       'TR_J4 (5.1)',
     ];

--- a/src/components/Counter/utils.test.js
+++ b/src/components/Counter/utils.test.js
@@ -18,6 +18,7 @@ describe('getDownloadCounterReportTypes', () => {
     const expectedValues = [
       { value: 'DR', label: 'DR (5.1)', release: '5.1' },
       { value: 'DR_D1', label: 'DR_D1 (5.1)', release: '5.1' },
+      { value: 'DR_D2', label: 'DR_D2 (5.1)', release: '5.1' },
     ];
     expect(getDownloadCounterReportTypes('5.1', 'DR')).toEqual(expectedValues);
   });

--- a/src/util/data/downloadReportTypesOptions.js
+++ b/src/util/data/downloadReportTypesOptions.js
@@ -1,8 +1,15 @@
-const release5Options = {
+const release50Options = {
   'DR': ['DR', 'DR_D1'],
   'IR': ['IR'],
   'PR': ['PR'],
   'TR': ['TR', 'TR_J1', 'TR_J3', 'TR_J4', 'TR_B1', 'TR_B3'],
+};
+
+const release51Options = {
+  'DR': ['DR', 'DR_D1', 'DR_D2'],
+  'IR': ['IR', 'IR_A1', 'IR_M1'],
+  'PR': ['PR', 'PR_1'],
+  'TR': ['TR', 'TR_J1', 'TR_J2', 'TR_J3', 'TR_J4', 'TR_B1', 'TR_B2', 'TR_B3'],
 };
 
 const rawDownloadCounterReportTypeMapping = {
@@ -13,8 +20,8 @@ const rawDownloadCounterReportTypeMapping = {
     'BR2': ['BR2'],
     'PR1': ['PR1'],
   },
-  '5': release5Options,
-  '5.1': release5Options,
+  '5': release50Options,
+  '5.1': release51Options,
 };
 
 export default rawDownloadCounterReportTypeMapping;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-359

* Updates the list of R5.1 report types that are available for download as CSV/XSLX