### PR TITLE
[UIEUS-399] Fix typo for report type `PR_P1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * COUNTER 5.1 Support: Download stored COUNTER 5.1 reports as CSV and XSLX ([UIEUS-359](https://folio-org.atlassian.net/browse/UIEUS-359))
 * Migrate react-intl to v7 ([UIEUS-393](https://folio-org.atlassian.net/browse/UIEUS-393))
 * Migrate stripes dependencies to their Sunflower versions ([UIEUS-392](https://folio-org.atlassian.net/browse/UIEUS-392))
+* Fix typo for report type `PR_P1` ([UIEUS-399](https://folio-org.atlassian.net/browse/UIEUS-399))
 
 ## [10.0.1](https://github.com/folio-org/ui-erm-usage/tree/v10.0.1) (2024-12-02)
 * Update translation for permission ([UIEUS-385](https://folio-org.atlassian.net/browse/UIEUS-385))

--- a/src/util/data/downloadReportTypesOptions.js
+++ b/src/util/data/downloadReportTypesOptions.js
@@ -8,7 +8,7 @@ const release50Options = {
 const release51Options = {
   'DR': ['DR', 'DR_D1', 'DR_D2'],
   'IR': ['IR', 'IR_A1', 'IR_M1'],
-  'PR': ['PR', 'PR_1'],
+  'PR': ['PR', 'PR_P1'],
   'TR': ['TR', 'TR_J1', 'TR_J2', 'TR_J3', 'TR_J4', 'TR_B1', 'TR_B2', 'TR_B3'],
 };
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-399

* Fixes report type typo `PR_1` to be `PR_P1`