### PR TITLE
UIEUS-517: Use NoPermissionMessage from stripes-leipzig-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-erm-usage
 
 ## 12.1.0 (IN PROGRESS)
+* Use NoPermissionMessage from stripes-leipzig-components ([UIEUS-517](https://folio-org.atlassian.net/browse/UIEUS-517))
 
 ## [12.0.0](https://github.com/folio-org/ui-erm-usage/tree/v12.0.0) (2026-04-17)
 * Flag uploaded reports: Indicate manual changes in stats table icon ([UIEUS-225](https://folio-org.atlassian.net/browse/UIEUS-225))

--- a/src/routes/UDPCreateRoute.js
+++ b/src/routes/UDPCreateRoute.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 
+import { NoPermissionMessage } from '@folio/stripes-leipzig-components';
 import { LoadingPane } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 
@@ -36,7 +37,7 @@ const UDPCreateRoute = ({
   const harvesterImpls = extractHarvesterImpls(resources);
   const aggregators = (resources.aggregators || {}).records || [];
 
-  if (!hasPerms) return <div>No Permission</div>;
+  if (!hasPerms) return <NoPermissionMessage />;
 
   if (fetchIsPending()) {
     return <LoadingPane onClose={handleClose} />;

--- a/src/routes/UDPEditRoute.js
+++ b/src/routes/UDPEditRoute.js
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
+import { NoPermissionMessage } from '@folio/stripes-leipzig-components';
 import { LoadingPane } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 
@@ -47,7 +48,7 @@ const UDPEditRoute = ({
   const aggregators = (resources.aggregators || {}).records || [];
   const udp = get(resources, 'usageDataProvider.records[0]', {});
 
-  if (!hasPerms) return <div>No Permission</div>;
+  if (!hasPerms) return <NoPermissionMessage />;
 
   if (fetchIsPending()) {
     return <LoadingPane onClose={handleClose} />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,9 +1614,9 @@
     redux-form "^8.3.0"
 
 "@folio/stripes-leipzig-components@^1.0.0":
-  version "1.0.1099000000000149"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-leipzig-components/-/stripes-leipzig-components-1.0.1099000000000149.tgz#121876eee837a3850413f0dc827608e608ccf218"
-  integrity sha512-FSr8BlEtlmAK6IS2AwIk7ssZuoopGPaUDSQKdpQQoWqjznzGFbjJsOdmH27SNdLCvrN32LDJhddRk128E2l0XA==
+  version "1.0.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-leipzig-components/-/stripes-leipzig-components-1.0.0.tgz#0cac9ed26d77577453e738f7f170e90d5f49ff0b"
+  integrity sha512-UpSC4GU+8AJwAhN7HTziKnlMmuEOo3yJfDuuJPSmv93OpRwutYTMbmBjo9y8GrvCgO5hQOQ8evA/hlY5e20osg==
   dependencies:
     final-form-arrays "^3.0.2"
     lodash "^4.17.4"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-517

- Remove in `ui-erm-usage`: `<div>No Permission</div>`
- Use component `NoPermissionMessage` from `stripes-leipzig-components` instead
(see https://github.com/folio-org/stripes-leipzig-components/pull/23)
- Update version of `stripes-leipzig-components`

**Note:** `NoPermissionsMessage` will be just visible if `module.erm-usage.enabled` is granted.