### PR TITLE
[UIEUS-521] Replace moment-timezone with dayjs and Intl.DateTimeFormat in date/time utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.1.0 (IN PROGRESS)
 * Use NoPermissionMessage from stripes-leipzig-components ([UIEUS-517](https://folio-org.atlassian.net/browse/UIEUS-517))
 * Replace hardcoded report release and report type mappings with backend /impl data and remove report release dropdown ([UIEUS-510](https://folio-org.atlassian.net/browse/UIEUS-510))
+* Replace `moment-timezone` with dayjs and `Intl.DateTimeFormat` in date/time utilities ([UIEUS-521](https://folio-org.atlassian.net/browse/UIEUS-521))
 
 ## [12.0.0](https://github.com/folio-org/ui-erm-usage/tree/v12.0.0) (2026-04-17)
 * Flag uploaded reports: Indicate manual changes in stats table icon ([UIEUS-225](https://folio-org.atlassian.net/browse/UIEUS-225))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "final-form": "^4.18.7",
     "final-form-arrays": "^3.0.2",
     "lodash": "^4.17.4",
-    "moment-timezone": "^0.5.14",
     "prop-types": "^15.6.0",
     "react-dropzone": "^10.2.2",
     "react-final-form": "^6.3.5",

--- a/src/util/dateTimeProcessing.js
+++ b/src/util/dateTimeProcessing.js
@@ -19,17 +19,33 @@ const padTwentyFourHourToken = (format) => format.replaceAll('H', 'HH');
 
 const getDateFormat = (locale) => getLocaleDateFormat({ intl: { locale } });
 
-const getTimeFormat = (locale) => {
-  const format = getLocaleDateFormat({ intl: { locale }, config: TIME_FORMAT_CONFIG });
-  return padTwentyFourHourToken(format);
-};
+const getRawTimeFormat = (locale) => getLocaleDateFormat({ intl: { locale }, config: TIME_FORMAT_CONFIG });
+
+// Format used to *render* a time. Padded so 24-hour locales show a leading
+// zero (e.g. "08:00").
+const getTimeFormat = (locale) => padTwentyFourHourToken(getRawTimeFormat(locale));
 
 export const combineDateTime = (date, time, locale, timezone) => {
   try {
+    const datePart = getDateFormat(locale);
+    // Accept both the padded display format ("08:00", as emitted by
+    // splitDateTime) and the raw unpadded format ("8:15", "0:00", as emitted
+    // by Stripes' Timepicker for 24-hour locales). Strict parsing against the
+    // padded format alone rejects the Timepicker's output, yielding a null
+    // startAt that the backend rejects with "must not be null".
+    //
+    // No locale is passed to dayjs: it parses against the globally-loaded dayjs
+    // locale, which Stripes sets to the active locale's compatible dayjs locale
+    // via loadDayJSLocale at startup. Passing the raw UI locale instead would
+    // break locale-specific tokens (the AM/PM meridiem) for region locales such
+    // as en-US, whose data dayjs never loads (only the parent "en"). The format
+    // strings are still derived from the full UI locale.
     const local = dayjs(
       `${date} ${time}`,
-      `${getDateFormat(locale)} ${getTimeFormat(locale)}`,
-      locale,
+      [
+        `${datePart} ${getTimeFormat(locale)}`,
+        `${datePart} ${getRawTimeFormat(locale)}`,
+      ],
       true
     );
 
@@ -37,8 +53,8 @@ export const combineDateTime = (date, time, locale, timezone) => {
       return local.tz(timezone, true).utc()
         .format('YYYY-MM-DDTHH:mm:ssZZ');
     }
-  } catch {
-    // fall through
+  } catch (e) {
+    console.warn(`combineDateTime failed to parse "${date} ${time}" (${locale}):`, e); // eslint-disable-line no-console
   }
 
   return null;
@@ -55,8 +71,8 @@ export const splitDateTime = (dateTime, locale, timezone) => {
         time: dT.format(getTimeFormat(locale)),
       };
     }
-  } catch {
-    // fall through
+  } catch (e) {
+    console.warn(`splitDateTime failed to parse "${dateTime}" (${locale}):`, e); // eslint-disable-line no-console
   }
 
   return { date: '', time: '' };

--- a/src/util/dateTimeProcessing.js
+++ b/src/util/dateTimeProcessing.js
@@ -1,34 +1,78 @@
-import moment from 'moment-timezone';
+import {
+  dayjs,
+  getLocaleDateFormat,
+} from '@folio/stripes/components';
+
+const TIME_FORMAT_CONFIG = { hour: 'numeric', minute: 'numeric' };
+
+const DATE_FORMAT_CONFIG = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
+
+// getLocaleDateFormat emits unpadded hour tokens (H, h) regardless of the
+// requested Intl `hour` style. Pad the 24-hour token (H -> HH) so 24-hour
+// locales render with a leading zero (e.g. "08:00") as users expect; leave
+// 12-hour locales unpadded ("2:00 AM"), which is the conventional form.
+const padTwentyFourHourToken = (format) => format.replaceAll('H', 'HH');
+
+const getDateFormat = (locale) => getLocaleDateFormat({ intl: { locale } });
+
+const getTimeFormat = (locale) => {
+  const format = getLocaleDateFormat({ intl: { locale }, config: TIME_FORMAT_CONFIG });
+  return padTwentyFourHourToken(format);
+};
 
 export const combineDateTime = (date, time, locale, timezone) => {
-  const localeData = moment().locale(locale)
-    .localeData();
-  const dateFormat = localeData.longDateFormat('L');
-  const timeFormat = localeData.longDateFormat('LT');
-  return moment
-    .tz(
-      date + ' ' + time,
-      dateFormat + ' ' + timeFormat,
-      timezone
-    )
-    .utc()
-    .format('YYYY-MM-DDTHH:mm:ssZZ');
+  try {
+    const local = dayjs(
+      `${date} ${time}`,
+      `${getDateFormat(locale)} ${getTimeFormat(locale)}`,
+      locale,
+      true
+    );
+
+    if (local.isValid()) {
+      return local.tz(timezone, true).utc()
+        .format('YYYY-MM-DDTHH:mm:ssZZ');
+    }
+  } catch {
+    // fall through
+  }
+
+  return null;
 };
 
 export const splitDateTime = (dateTime, locale, timezone) => {
-  const dT = moment(dateTime).locale(locale)
-    .tz(timezone);
-  return {
-    date: dT.format('L'),
-    time: dT.format('LT'),
-  };
+  try {
+    const dT = dayjs(dateTime).tz(timezone)
+      .locale(locale);
+
+    if (dT.isValid()) {
+      return {
+        date: dT.format(getDateFormat(locale)),
+        time: dT.format(getTimeFormat(locale)),
+      };
+    }
+  } catch {
+    // fall through
+  }
+
+  return { date: '', time: '' };
 };
 
 export const formatDateTime = (dateTime, locale, timezone) => {
-  return dateTime
-    ? moment
-      .tz(dateTime, timezone)
-      .locale(locale)
-      .format('LLL')
-    : '--';
+  if (dateTime) {
+    const date = new Date(dateTime);
+
+    if (Number.isFinite(date.getTime())) {
+      return [
+        new Intl.DateTimeFormat(locale, { ...DATE_FORMAT_CONFIG, timeZone: timezone }).format(date),
+        new Intl.DateTimeFormat(locale, { ...TIME_FORMAT_CONFIG, timeZone: timezone }).format(date),
+      ].join(' ');
+    }
+  }
+
+  return '--';
 };

--- a/src/util/dateTimeProcessing.test.js
+++ b/src/util/dateTimeProcessing.test.js
@@ -37,6 +37,20 @@ describe('combineDateTime', () => {
     ['de', 'Europe/Berlin', '20.06.2023', '08:00', '2023-06-20T06:00:00+0000'],
     ['en', 'America/New_York', '06/20/2023', '2:00 AM', '2023-06-20T06:00:00+0000'],
     ['en-SE', 'Europe/Stockholm', '2026-04-30', '08:15', '2026-04-30T06:15:00+0000'],
+    // The Timepicker emits unpadded 24-hour times for de/en-SE locales
+    // ("8:15", "0:00"); these must parse as well as the padded display form.
+    ['de', 'Europe/Berlin', '20.06.2023', '8:15', '2023-06-20T06:15:00+0000'],
+    ['en-SE', 'Europe/Stockholm', '2026-04-30', '8:15', '2026-04-30T06:15:00+0000'],
+    // Midnight, in both the picker's unpadded form and the padded display form.
+    ['de', 'Europe/Berlin', '20.06.2023', '0:00', '2023-06-19T22:00:00+0000'],
+    ['de', 'Europe/Berlin', '20.06.2023', '00:00', '2023-06-19T22:00:00+0000'],
+    ['en', 'America/New_York', '06/20/2023', '12:00 AM', '2023-06-20T04:00:00+0000'],
+    // Region locale (en-US, FOLIO's default). dayjs only loads the parent "en"
+    // locale, so the AM/PM meridiem must be parsed against the parent language
+    // rather than the unloaded region locale.
+    ['en-US', 'America/New_York', '06/20/2023', '7:00 AM', '2023-06-20T11:00:00+0000'],
+    ['en-US', 'America/New_York', '06/20/2023', '12:00 AM', '2023-06-20T04:00:00+0000'],
+    ['en-US', 'America/New_York', '06/20/2023', '2:00 PM', '2023-06-20T18:00:00+0000'],
   ];
 
   test.each(cases)(

--- a/src/util/dateTimeProcessing.test.js
+++ b/src/util/dateTimeProcessing.test.js
@@ -1,18 +1,21 @@
+import { loadDayJSLocale } from '@folio/stripes/components';
+
 import {
   combineDateTime,
   formatDateTime,
   splitDateTime,
 } from './dateTimeProcessing';
 
-describe('test split', () => {
-  const splitCases = [
+describe('splitDateTime', () => {
+  const cases = [
     ['de', 'Europe/Berlin', '2023-06-20T06:00:00+0000', '20.06.2023', '08:00'],
     ['de', 'Europe/Berlin', '2023-06-20T08:00:00+0200', '20.06.2023', '08:00'],
     ['en', 'America/New_York', '2023-06-20T06:00:00+0000', '06/20/2023', '2:00 AM'],
     ['en', 'America/New_York', '2023-06-20T02:00:00-0400', '06/20/2023', '2:00 AM'],
+    ['en-SE', 'Europe/Stockholm', '2026-04-30T06:15:00+0000', '2026-04-30', '08:15'],
   ];
 
-  test.each(splitCases)(
+  test.each(cases)(
     '%s %s %s -> %s %s',
     (locale, timezone, dateTime, date, time) => {
       const split = splitDateTime(dateTime, locale, timezone);
@@ -20,33 +23,80 @@ describe('test split', () => {
       expect(split.time).toBe(time);
     }
   );
+
+  it('returns blank fields for an invalid input', () => {
+    expect(splitDateTime('not-a-date', 'en-SE', 'Europe/Stockholm')).toEqual({
+      date: '',
+      time: '',
+    });
+  });
 });
 
-describe('test combine', () => {
-  const combineCases = [
+describe('combineDateTime', () => {
+  const cases = [
     ['de', 'Europe/Berlin', '20.06.2023', '08:00', '2023-06-20T06:00:00+0000'],
     ['en', 'America/New_York', '06/20/2023', '2:00 AM', '2023-06-20T06:00:00+0000'],
+    ['en-SE', 'Europe/Stockholm', '2026-04-30', '08:15', '2026-04-30T06:15:00+0000'],
   ];
-  test.each(combineCases)(
+
+  test.each(cases)(
     '%s %s %s %s -> %s',
-    (locale, timezone, date, time, dateTime) => {
-      const combined = combineDateTime(date, time, locale, timezone);
-      expect(combined).toBe(dateTime);
+    (locale, timezone, date, time, expected) => {
+      expect(combineDateTime(date, time, locale, timezone)).toBe(expected);
     }
   );
+
+  const invalidCases = [
+    ['unparseable date', 'Invalid date', '08:00'],
+    ['unparseable time', '2026-04-30', 'Invalid date'],
+    ['impossible calendar date', '2026-02-31', '08:15'],
+  ];
+
+  it.each(invalidCases)('returns null for %s', (_, date, time) => {
+    expect(combineDateTime(date, time, 'en-SE', 'Europe/Stockholm')).toBeNull();
+  });
 });
 
-describe('test format', () => {
-  const combineCases = [
+describe('locale-aware round-trip', () => {
+  // Coverage for a locale with non-English meridiem text (ko). The snapshot
+  // anchors the exact strings Stripes' pickers consume and emit; the
+  // round-trip case proves the locale survives an Edit-and-Save cycle.
+  const original = '2026-04-30T06:15:00+0000';
+
+  beforeAll(async () => {
+    await new Promise((resolve) => loadDayJSLocale('ko', resolve));
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => loadDayJSLocale('en', resolve));
+  });
+
+  it('matches the picker-normalized ko strings', () => {
+    expect(splitDateTime(original, 'ko', 'Asia/Seoul')).toEqual({
+      date: '2026. 04. 30.',
+      time: '오후 15:15',
+    });
+  });
+
+  it('ko round-trips', () => {
+    const { date, time } = splitDateTime(original, 'ko', 'Asia/Seoul');
+    expect(combineDateTime(date, time, 'ko', 'Asia/Seoul')).toBe(original);
+  });
+});
+
+describe('formatDateTime', () => {
+  const cases = [
     ['de', 'Europe/Berlin', '2023-06-20T06:00:00+0000', '20. Juni 2023 08:00'],
     ['en', 'America/New_York', '2023-06-20T02:00:00-0400', 'June 20, 2023 2:00 AM'],
+    ['en-SE', 'Europe/Stockholm', '2026-04-30T06:15:00+0000', '30 April 2026 08:15'],
     ['en', 'America/New_York', undefined, '--'],
+    ['en', 'America/New_York', 'garbage', '--'],
   ];
-  test.each(combineCases)(
+
+  test.each(cases)(
     '%s %s %s -> %s',
     (locale, timezone, dateTime, expected) => {
-      const formatted = formatDateTime(dateTime, locale, timezone);
-      expect(formatted).toBe(expected);
+      expect(formatDateTime(dateTime, locale, timezone)).toBe(expected);
     }
   );
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-521

## Purpose

Users with the English (Sweden) `en-SE` locale cannot save changes to periodic harvesting configuration through Settings -> eUsage -> Harvester -> Periodic harvesting. Clicking Save produces a 400 error because the `startAt` field is sent as the literal string "Invalid date" instead of an ISO 8601 timestamp.

The root cause is a mismatch between the date format emitted by the Stripes Datepicker and the format the parsing utility expects. The Datepicker formats dates via `Intl.DateTimeFormat` for the user's locale (`en-SE` uses `YYYY-MM-DD`), while the parsing utility derives its expected format from moment-timezone locale data. moment lacks `en-SE` data and falls back to the English defaults (`MM/DD/YYYY`), so strict parsing fails and yields "Invalid date".

## Approach

- Replace `moment-timezone` with `dayjs` and `Intl.DateTimeFormat` in `src/util/dateTimeProcessing.js`.
- Derive the locale date and time format from Stripes's `getLocaleDateFormat` helper so the parsing format matches what the Datepicker and Timepicker emit.
- Use strict dayjs parsing and guard against invalid inputs so `combineDateTime` returns `null` (and `splitDateTime` returns empty strings) instead of the literal "Invalid date".
- Pad the 24-hour token (`H` -> `HH`) returned by `getLocaleDateFormat` for display, but parse `combineDateTime` against both the padded display format (`08:00`) and the raw unpadded format (`8:15`, `0:00`). The Stripes Timepicker emits unpadded times for 24-hour locales, so parsing against the padded format alone rejected its output and sent a `null` `startAt` (which the backend rejected with "must not be null"). This blocked saving midnight and any single-digit-hour time.
- Parse the time against the globally-loaded dayjs locale rather than the raw UI locale. Stripes sets the global dayjs locale to the active locale's compatible dayjs locale via `loadDayJSLocale` at startup. Passing the raw UI locale to dayjs instead made strict parsing of locale-specific tokens (the AM/PM meridiem) fail for region locales such as `en-US`, whose data dayjs never loads (only the parent `en`), producing a `null` `startAt` for 12-hour locales including FOLIO's default. The format strings are still derived from the full UI locale.
- Log the offending input in the `combineDateTime` and `splitDateTime` `catch` blocks instead of silently falling through, so parse failures are visible during development.
- Drop the `moment-timezone` dependency from `package.json`.
- Update unit tests in `src/util/dateTimeProcessing.test.js` to cover the new behavior and locale handling.