### PR TITLE
UIEUS-519: Trim serviceUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.1.0 (IN PROGRESS)
 * Use NoPermissionMessage from stripes-leipzig-components ([UIEUS-517](https://folio-org.atlassian.net/browse/UIEUS-517))
 * Replace hardcoded report release and report type mappings with backend /impl data and remove report release dropdown ([UIEUS-510](https://folio-org.atlassian.net/browse/UIEUS-510))
+* Service URL: Automatically remove whitespaces at the begin and the end ([UIEUS-519](https://folio-org.atlassian.net/browse/UIEUS-519))
 
 ## [12.0.0](https://github.com/folio-org/ui-erm-usage/tree/v12.0.0) (2026-04-17)
 * Flag uploaded reports: Indicate manual changes in stats table icon ([UIEUS-225](https://folio-org.atlassian.net/browse/UIEUS-225))

--- a/src/components/HarvestingConfiguration/VendorInfo/VendorInfoForm.js
+++ b/src/components/HarvestingConfiguration/VendorInfo/VendorInfoForm.js
@@ -77,6 +77,7 @@ const VendorInfoForm = ({
               </>
             }
             name="harvestingConfig.sushiConfig.serviceUrl"
+            parse={value => value?.trim()}
             placeholder={intl.formatMessage({
               id: 'ui-erm-usage.udp.form.placeholder.vendor.url',
             })}

--- a/src/components/views/UDPForm.test.js
+++ b/src/components/views/UDPForm.test.js
@@ -205,6 +205,21 @@ describe('UDPForm', () => {
     });
   });
 
+  describe('service url trimming', () => {
+    beforeEach(() => {
+      renderUDPForm(stripes);
+    });
+
+    test('trims whitespace from service url', async () => {
+      const serviceUrlInput = screen.getByRole('textbox', { name: /service url/i });
+      await userEvent.click(serviceUrlInput);
+      await userEvent.paste('  http://example.com/sushi   ');
+      await userEvent.tab();
+
+      expect(serviceUrlInput).toHaveValue('http://example.com/sushi');
+    });
+  });
+
   describe('test service type and selected reports options', () => {
     beforeEach(() => {
       renderUDPForm(stripes, {});

--- a/src/settings/Aggregators/AggregatorForm.js
+++ b/src/settings/Aggregators/AggregatorForm.js
@@ -274,6 +274,7 @@ const AggregatorForm = ({
                       id="input-aggregator-service-url"
                       label={<FormattedMessage id="ui-erm-usage.aggregator.serviceUrl" />}
                       name="serviceUrl"
+                      parse={value => value?.trim()}
                       required
                       validate={required}
                     />

--- a/src/settings/Aggregators/AggregatorForm.test.js
+++ b/src/settings/Aggregators/AggregatorForm.test.js
@@ -87,6 +87,15 @@ describe('AggregatorForm', () => {
     await userEvent.click(trashBtn);
     expect(screen.queryByText('Key')).not.toBeInTheDocument();
   });
+
+  test('trims whitespace from service url', async () => {
+    const serviceUrlInput = screen.getByRole('textbox', { name: /service url/i });
+    await userEvent.click(serviceUrlInput);
+    await userEvent.paste('  http://example.com/sushi   ');
+    await userEvent.tab();
+
+    expect(serviceUrlInput).toHaveValue('http://example.com/sushi');
+  });
 });
 
 describe('Edit Aggregator', () => {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-519

**Description:**

Remove whitespace characters automatically of **serviceUrl** in Settings - `AggregatorForm.js` and UDPForm - `VendorInfoForm.js`


**Return value of `trim()`:**

A new string representing str from which all _whitespace_ characters have been removed _from_ both _the beginning and the end_. Whitespace characters are defined as **[white space characters](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Lexical_grammar#white_space)** plus **[line terminators](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Lexical_grammar#line_terminators)**.