### PR TITLE
UIEUS-522: Fix delete while editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Use NoPermissionMessage from stripes-leipzig-components ([UIEUS-517](https://folio-org.atlassian.net/browse/UIEUS-517))
 * Replace hardcoded report release and report type mappings with backend /impl data and remove report release dropdown ([UIEUS-510](https://folio-org.atlassian.net/browse/UIEUS-510))
 * Replace `moment-timezone` with dayjs and `Intl.DateTimeFormat` in date/time utilities ([UIEUS-521](https://folio-org.atlassian.net/browse/UIEUS-521))
+* Fix deleting while editing a UDP record ([UIEUS-522](https://folio-org.atlassian.net/browse/UIEUS-522))
 
 ## [12.0.0](https://github.com/folio-org/ui-erm-usage/tree/v12.0.0) (2026-04-17)
 * Flag uploaded reports: Indicate manual changes in stats table icon ([UIEUS-225](https://folio-org.atlassian.net/browse/UIEUS-225))

--- a/src/components/views/UDPForm.js
+++ b/src/components/views/UDPForm.js
@@ -279,7 +279,7 @@ UDPForm.propTypes = {
       clearSelectedReports: PropTypes.func,
       setReportRelease: PropTypes.func,
     }),
-    reset: PropTypes.func,
+    reset: PropTypes.func.isRequired,
     resetFieldState: PropTypes.func,
   }),
   handlers: PropTypes.shape({

--- a/src/components/views/UDPForm.js
+++ b/src/components/views/UDPForm.js
@@ -90,6 +90,7 @@ const UDPForm = ({
 
   const doConfirmDelete = (confirmation) => {
     if (confirmation) {
+      form.reset();
       handlers.onDelete(initialValues.id);
     } else {
       setConfirmDelete(false);
@@ -278,6 +279,7 @@ UDPForm.propTypes = {
       clearSelectedReports: PropTypes.func,
       setReportRelease: PropTypes.func,
     }),
+    reset: PropTypes.func,
     resetFieldState: PropTypes.func,
   }),
   handlers: PropTypes.shape({

--- a/src/components/views/UDPForm.test.js
+++ b/src/components/views/UDPForm.test.js
@@ -338,6 +338,19 @@ describe('UDPForm', () => {
       await userEvent.click(submit);
       expect(onDelete).toHaveBeenCalled();
     });
+
+    test('delete with unsaved changes resets the form before calling onDelete', async () => {
+      const descriptionInput = screen.getByRole('textbox', { name: /description/i });
+      await userEvent.type(descriptionInput, 'some change');
+      expect(descriptionInput).toHaveValue('some change');
+
+      await userEvent.click(await screen.findByText('Delete'));
+      const deleteModal = screen.getByRole('dialog', { name: /Do you really want to delete/ });
+      await userEvent.click(within(deleteModal).getByRole('button', { name: 'Submit' }));
+
+      expect(onDelete).toHaveBeenCalledWith(initialUdp.id);
+      expect(descriptionInput).toHaveValue('');
+    });
   });
 
   describe('test change from sushi to aggregator', () => {

--- a/src/settings/Aggregators/AggregatorForm.js
+++ b/src/settings/Aggregators/AggregatorForm.js
@@ -58,6 +58,7 @@ const AggregatorForm = ({
   initialValues,
   intl,
   invalid,
+  form,
   handleSubmit,
   onCancel,
   onRemove,
@@ -97,6 +98,7 @@ const AggregatorForm = ({
 
   const doConfirmDelete = (confirmation) => {
     if (confirmation) {
+      form.reset();
       onRemove(initialValues);
     } else {
       setConfirmDelete(false);
@@ -349,6 +351,9 @@ const AggregatorForm = ({
 
 AggregatorForm.propTypes = {
   aggregators: PropTypes.arrayOf(PropTypes.object).isRequired,
+  form: PropTypes.shape({
+    reset: PropTypes.func.isRequired,
+  }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   initialValues: PropTypes.object,
   intl: PropTypes.object,

--- a/src/settings/Aggregators/AggregatorForm.test.js
+++ b/src/settings/Aggregators/AggregatorForm.test.js
@@ -127,6 +127,19 @@ describe('Edit Aggregator', () => {
     });
   });
 
+  test('delete with unsaved changes resets the form to initial values before calling onRemove', async () => {
+    const nameInput = screen.getByLabelText('Name', { exact: false });
+    await userEvent.type(nameInput, ' changed');
+    expect(nameInput).toHaveValue(`${aggregatorTransformed.label} changed`);
+
+    await userEvent.click(await screen.findByText('Delete'));
+    const deleteModal = screen.getByRole('dialog', { name: /Do you really want to delete/ });
+    await userEvent.click(within(deleteModal).getByRole('button', { name: 'Submit' }));
+
+    expect(onRemove).toHaveBeenCalledWith(aggregatorTransformed);
+    expect(nameInput).toHaveValue(aggregatorTransformed.label);
+  });
+
   test('adding "contact" enables save button, removing "contact" disables save button', async () => {
     const saveButton = screen.getByRole('button', { name: 'Save & close' });
     expect(saveButton).toBeDisabled();


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-522

### Description 

**Steps to reproduce:**
- Editing an existing UDP record. 
- Instead of saving, the user clicks **Delete**.
- The user clicks Submit in the dialog window for deleting the record.
**Expected result:** The record will be deleted. The editing window will close. The user is now back at the overview of the UDP entries that have been created.
**Actual result:** After the delete process is initiated by clicking the Submit button, the user interface checks for changes — a step that is actually only necessary when saving. This means that the dialog window for unsaved changes is displayed. However, the record has already been deleted by that point. This then results in corresponding error messages.

### Approach

- Reset the form after confirming deletion for `UPDForm` and `AggregatorForm`
- Add test.