### PR TITLE
UIEUS-523: Show 'Please enter a valid date' instead of 'Required' for invalid periodic harvesting start date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Replace hardcoded report release and report type mappings with backend /impl data and remove report release dropdown ([UIEUS-510](https://folio-org.atlassian.net/browse/UIEUS-510))
 * Replace `moment-timezone` with dayjs and `Intl.DateTimeFormat` in date/time utilities ([UIEUS-521](https://folio-org.atlassian.net/browse/UIEUS-521))
 * Service URL: Automatically remove whitespaces at the begin and the end ([UIEUS-519](https://folio-org.atlassian.net/browse/UIEUS-519))
+* Periodic harvesting: Show "Please enter a valid date" instead of "Required" for an invalid start date ([UIEUS-523](https://folio-org.atlassian.net/browse/UIEUS-523))
 
 ## [12.0.0](https://github.com/folio-org/ui-erm-usage/tree/v12.0.0) (2026-04-17)
 * Flag uploaded reports: Indicate manual changes in stats table icon ([UIEUS-225](https://folio-org.atlassian.net/browse/UIEUS-225))

--- a/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.js
+++ b/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.js
@@ -22,7 +22,10 @@ import stripesFinalForm from '@folio/stripes/final-form';
 
 import periodicHarvestingIntervals from '../../util/data/periodicHarvestingIntervals';
 import { formatDateTime } from '../../util/dateTimeProcessing';
-import { required } from '../../util/validate';
+import {
+  required,
+  requiredValidDate,
+} from '../../util/validate';
 
 const PeriodicHarvestingForm = ({
   handleSubmit,
@@ -59,7 +62,7 @@ const PeriodicHarvestingForm = ({
               label={<FormattedMessage id="ui-erm-usage.settings.harvester.config.periodic.start.date" />}
               name="date"
               outputFormatter={({ value }) => value}
-              validate={required}
+              validate={requiredValidDate}
             />
           </Col>
         </Row>

--- a/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.test.js
+++ b/src/settings/PeriodicHarvesting/PeriodicHarvestingForm.test.js
@@ -54,7 +54,23 @@ describe('PeriodicHarvestingForm', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
 
     await userEvent.click(screen.getByText('Save'));
-    expect(screen.queryAllByText('Required')).toHaveLength(2);
+    expect(screen.getByText('Please enter a valid date')).toBeInTheDocument();
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test('test invalid date', async () => {
+    onSubmit.mockClear();
+    renderPeriodicHarvestingForm(stripes);
+
+    await userEvent.type(
+      screen.getByLabelText('Start date', { exact: false }),
+      '2026-10-77'
+    );
+    await userEvent.type(screen.getByText('Start time', { exact: false }), '5:01 AM');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('Please enter a valid date')).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -72,6 +88,7 @@ describe('PeriodicHarvestingForm', () => {
 
     await userEvent.click(screen.getByText('Save'));
     expect(screen.queryByText('Required')).not.toBeInTheDocument();
+    expect(screen.queryByText('Please enter a valid date')).not.toBeInTheDocument();
     expect(onSubmit).toHaveBeenCalled();
   });
 

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -8,6 +8,13 @@ const required = value => {
 
 const notRequired = () => undefined;
 
+// the Datepicker commits an unparseable entry as an empty value,
+// so this single message covers both the empty and the invalid case
+const requiredValidDate = value => {
+  if (value) return undefined;
+  return <FormattedMessage id="ui-erm-usage.errors.enterValidDate" />;
+};
+
 const requiredArray = value => {
   if (value && value.length > 0) return undefined;
   return <FormattedMessage id="ui-erm-usage.errors.required" />;
@@ -94,6 +101,7 @@ export {
   notRequired,
   required,
   requiredArray,
+  requiredValidDate,
   yearMonth,
   requiredValidateUrl,
 };

--- a/src/util/validate.test.js
+++ b/src/util/validate.test.js
@@ -1,4 +1,7 @@
-import { isValidUrl } from './validate';
+import {
+  isValidUrl,
+  requiredValidDate,
+} from './validate';
 
 describe('isValidUrl function', () => {
   test('validates URLs correctly', () => {
@@ -15,6 +18,18 @@ describe('isValidUrl function', () => {
 
     urls.forEach(({ input, expected }) => {
       expect(isValidUrl(input)).toBe(expected);
+    });
+  });
+});
+
+describe('requiredValidDate function', () => {
+  test('returns undefined for a non-empty value', () => {
+    expect(requiredValidDate('2026-10-07')).toBeUndefined();
+  });
+
+  test('returns the valid-date message for empty values', () => {
+    [undefined, null, ''].forEach((value) => {
+      expect(requiredValidDate(value).props.id).toBe('ui-erm-usage.errors.enterValidDate');
     });
   });
 });

--- a/translations/ui-erm-usage/en.json
+++ b/translations/ui-erm-usage/en.json
@@ -262,6 +262,7 @@
   "errors.endDateMustBeGraterStartDate": "End date must be greater than start date",
   "errors.urlRequired": "Invalid URL: http:// or https:// required!",
   "errors.enterValidUrl": "Please enter a valid URL",
+  "errors.enterValidDate": "Please enter a valid date",
 
   "harvester.start": "Start harvester",
   "harvester.start.failed": "Harvester failed to start",


### PR DESCRIPTION
Fixes [UIEUS-523](https://folio-org.atlassian.net/browse/UIEUS-523).

On the periodic harvesting form, entering an invalid start date such as `2026-10-77` showed the validation message "Required" even though the field was not empty. The Datepicker commits an unparseable entry as an empty value, so the `required` validator could not distinguish an invalid entry from an empty field.

## Changes
- Add `requiredValidDate` validator that returns a localized "Please enter a valid date" for an empty/invalid value and use it on the start-date field
- Add translation key `errors.enterValidDate`
- Add unit tests for the validator and the form's invalid-date case
