### PR TITLE
UIEUS-527: Move delete button for an aggregator in the settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Replace `moment-timezone` with dayjs and `Intl.DateTimeFormat` in date/time utilities ([UIEUS-521](https://folio-org.atlassian.net/browse/UIEUS-521))
 * Service URL: Automatically remove whitespaces at the begin and the end ([UIEUS-519](https://folio-org.atlassian.net/browse/UIEUS-519))
 * Periodic harvesting: Show "Please enter a valid date" instead of "Required" for an invalid start date ([UIEUS-523](https://folio-org.atlassian.net/browse/UIEUS-523))
+* New position for the Delete button used to delete an aggregator record in the settings ([UIEUS-527](https://folio-org.atlassian.net/browse/UIEUS-527))
 
 ## [12.0.0](https://github.com/folio-org/ui-erm-usage/tree/v12.0.0) (2026-04-17)
 * Flag uploaded reports: Indicate manual changes in stats table icon ([UIEUS-225](https://folio-org.atlassian.net/browse/UIEUS-225))

--- a/src/settings/Aggregators/AggregatorForm.js
+++ b/src/settings/Aggregators/AggregatorForm.js
@@ -13,7 +13,6 @@ import {
   AccordionSet,
   Button,
   Col,
-  ConfirmationModal,
   ExpandAllButton,
   Icon,
   IconButton,
@@ -26,7 +25,6 @@ import {
   Select,
   TextField,
 } from '@folio/stripes/components';
-import { IfPermission } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
 
 import aggregatorAccountConfigTypes from '../../util/data/aggregatorAccountConfigTypes';
@@ -60,15 +58,11 @@ const AggregatorForm = ({
   invalid,
   handleSubmit,
   onCancel,
-  onRemove,
   pristine,
   submitting,
   values,
   aggregators,
 }) => {
-  const aggregator = initialValues || {};
-
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [sections, setSections] = useState({
     generalSection: true,
     aggregatorConfig: true,
@@ -91,18 +85,6 @@ const AggregatorForm = ({
     }
   };
 
-  const beginDelete = () => {
-    setConfirmDelete(true);
-  };
-
-  const doConfirmDelete = (confirmation) => {
-    if (confirmation) {
-      onRemove(initialValues);
-    } else {
-      setConfirmDelete(false);
-    }
-  };
-
   const getFirstMenu = () => {
     return (
       <PaneMenu>
@@ -112,28 +94,6 @@ const AggregatorForm = ({
           id="clickable-close-service-point"
           onClick={onCancel}
         />
-      </PaneMenu>
-    );
-  };
-
-  const getLastMenu = () => {
-    const edit = initialValues?.id;
-
-    return (
-      <PaneMenu>
-        {edit && (
-          <IfPermission perm="ui-erm-usage.generalSettings.manage">
-            <Button
-              buttonStyle="danger"
-              disabled={confirmDelete}
-              id="clickable-delete-aggregator"
-              marginBottom0
-              onClick={beginDelete}
-            >
-              <FormattedMessage id="ui-erm-usage.general.delete" />
-            </Button>
-          </IfPermission>
-        )}
       </PaneMenu>
     );
   };
@@ -196,23 +156,14 @@ const AggregatorForm = ({
   const renderPaneHeader = () => (
     <PaneHeader
       firstMenu={getFirstMenu()}
-      lastMenu={getLastMenu()}
       paneTitle={renderPaneTitle()}
     />
   );
 
   const disabled = !stripes.hasPerm('ui-erm-usage.generalSettings.manage');
-  const name = aggregator.label || '';
 
   const configType = getSelectedConfigType();
   const configTypeIsMail = configType === 'Mail';
-
-  const confirmationMessage = (
-    <FormattedMessage
-      id="ui-erm-usage.form.delete.confirm.message"
-      values={{ name }}
-    />
-  );
 
   return (
     <form
@@ -328,19 +279,6 @@ const AggregatorForm = ({
                 </Row>
               </Accordion>
             </AccordionSet>
-
-            <ConfirmationModal
-              heading={<FormattedMessage id="ui-erm-usage.aggregator.form.delete.confirm.title" />}
-              id="deleteaggregator-confirmation"
-              message={confirmationMessage}
-              onCancel={() => {
-                doConfirmDelete(false);
-              }}
-              onConfirm={() => {
-                doConfirmDelete(true);
-              }}
-              open={confirmDelete}
-            />
           </div>
         </Pane>
       </Paneset>
@@ -355,12 +293,7 @@ AggregatorForm.propTypes = {
   intl: PropTypes.object,
   invalid: PropTypes.bool,
   onCancel: PropTypes.func,
-  onRemove: PropTypes.func,
   pristine: PropTypes.bool,
-  stripes: PropTypes.shape({
-    connect: PropTypes.func.isRequired,
-    hasPerm: PropTypes.func.isRequired,
-  }).isRequired,
   submitting: PropTypes.bool,
   values: PropTypes.object,
 };

--- a/src/settings/Aggregators/AggregatorForm.js
+++ b/src/settings/Aggregators/AggregatorForm.js
@@ -294,6 +294,9 @@ AggregatorForm.propTypes = {
   invalid: PropTypes.bool,
   onCancel: PropTypes.func,
   pristine: PropTypes.bool,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
   submitting: PropTypes.bool,
   values: PropTypes.object,
 };

--- a/src/settings/Aggregators/AggregatorForm.test.js
+++ b/src/settings/Aggregators/AggregatorForm.test.js
@@ -23,7 +23,6 @@ const aggregators = [
 ];
 
 const onSubmit = jest.fn();
-const onRemove = jest.fn();
 const onCancel = jest.fn();
 
 const renderAggregratorForm = (stripes, initialValues = {}) => {
@@ -34,7 +33,6 @@ const renderAggregratorForm = (stripes, initialValues = {}) => {
           aggregators={aggregators}
           initialValues={initialValues}
           onCancel={onCancel}
-          onRemove={onRemove}
           onSubmit={onSubmit}
           stripes={stripes}
         />

--- a/src/settings/Aggregators/AggregatorForm.test.js
+++ b/src/settings/Aggregators/AggregatorForm.test.js
@@ -3,7 +3,6 @@ import { MemoryRouter } from 'react-router-dom';
 import {
   screen,
   waitFor,
-  within,
 } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import {
@@ -153,35 +152,5 @@ describe('Edit Aggregator', () => {
     await waitFor(() => {
       expect(saveButton).toBeDisabled();
     });
-  });
-});
-
-describe('Delete Aggregator', () => {
-  let stripes;
-
-  beforeEach(async () => {
-    stripes = useStripes();
-    renderAggregratorForm(stripes, aggregatorTransformed);
-
-    const deleteBtn = screen.getByRole('button', { name: 'Delete' });
-    await userEvent.click(deleteBtn);
-  });
-
-  test('click cancel', async () => {
-    const deleteModalText = screen.getByRole('heading', { name: 'Delete aggregator' });
-    expect(deleteModalText).toBeInTheDocument();
-
-    const deleteModal = screen.getByRole('dialog', { name: /Do you really want to delete/ });
-    expect(deleteModal).toBeVisible();
-
-    const cancelButton = within(deleteModal).getByRole('button', { name: 'Cancel' });
-    await userEvent.click(cancelButton);
-    expect(deleteModalText).not.toBeInTheDocument();
-  });
-
-  test('click submit', async () => {
-    const submitBtn = screen.getByRole('button', { name: 'Submit' });
-    await userEvent.click(submitBtn);
-    expect(onRemove).toHaveBeenCalled();
   });
 });

--- a/src/settings/Aggregators/AggregatorManager.js
+++ b/src/settings/Aggregators/AggregatorManager.js
@@ -80,6 +80,7 @@ const AggregatorManager = ({
       <EntryManager
         aggregators={serviceTypes}
         detailComponent={AggregatorDetails}
+        enableDetailsActionMenu
         entryFormComponent={AggregatorForm}
         entryLabel={label}
         entryList={entryList}

--- a/src/settings/Aggregators/AggregatorManager.test.js
+++ b/src/settings/Aggregators/AggregatorManager.test.js
@@ -1,43 +1,54 @@
+import { MemoryRouter } from 'react-router-dom';
+
 import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import {
+  CalloutContext,
+  StripesContext,
+  useStripes,
+} from '@folio/stripes/core';
 import { EntryManager } from '@folio/stripes/smart-components';
 
+import aggregator from '../../../test/fixtures/aggregator';
 import renderWithIntl from '../../../test/jest/helpers';
 import AggregatorManager from './AggregatorManager';
+
+const ActualEntryManager = jest.requireActual('@folio/stripes/smart-components').EntryManager;
 
 jest.mock('@folio/stripes/smart-components', () => ({
   EntryManager: jest.fn(() => <div data-testid="entry-manager" />),
 }));
 
-describe('AggregatorManager', () => {
-  const defaultProps = {
-    label: 'Test Label',
-    resources: {
-      entries: {
-        records: [
-          { label: 'Entry A' },
-          { label: 'Entry B' },
-        ],
-      },
-      aggregatorImpls: {
-        records: [
-          {
-            implementations: [
-              { type: 'type1', name: 'Implementation 1' },
-              { type: 'type2', name: 'Implementation 2' },
-            ],
-          },
-        ],
-      },
+const defaultProps = {
+  label: 'Test Label',
+  resources: {
+    entries: {
+      records: [
+        { label: 'Entry A' },
+        { label: 'Entry B' },
+      ],
     },
-    mutator: {
-      entries: {
-        POST: jest.fn(),
-        PUT: jest.fn(),
-        DELETE: jest.fn(),
-      },
+    aggregatorImpls: {
+      records: [
+        {
+          implementations: [
+            { type: 'type1', name: 'Implementation 1' },
+            { type: 'type2', name: 'Implementation 2' },
+          ],
+        },
+      ],
     },
-  };
+  },
+  mutator: {
+    entries: {
+      POST: jest.fn(),
+      PUT: jest.fn(),
+      DELETE: jest.fn(),
+    },
+  },
+};
 
+describe('AggregatorManager', () => {
   it('should render AggregatorManager and EntryManager', () => {
     renderWithIntl(<AggregatorManager {...defaultProps} />);
 
@@ -104,5 +115,55 @@ describe('AggregatorManager', () => {
       }),
       {}
     );
+  });
+});
+
+describe('Aggregator action menu', () => {
+  // Smoke test with the real EntryManager (not the stub above): confirms
+  // that our wiring (enableDetailsActionMenu + the put/post/delete
+  // permissions) actually produces a Duplicate/Edit/Delete action menu.
+  const actionMenuProps = {
+    ...defaultProps,
+    resources: {
+      ...defaultProps.resources,
+      entries: { records: [aggregator] },
+    },
+  };
+
+  beforeEach(() => {
+    EntryManager.mockImplementation((props) => <ActualEntryManager {...props} />);
+
+    // EntryManager's Layer portals into #ModuleContainer, which must
+    // already exist in the DOM before the first render commits.
+    document.body.appendChild(Object.assign(document.createElement('div'), { id: 'ModuleContainer' }));
+  });
+
+  afterEach(() => {
+    EntryManager.mockImplementation(() => <div data-testid="entry-manager" />);
+    document.getElementById('ModuleContainer')?.remove();
+  });
+
+  test('offers duplicate, edit and delete', async () => {
+    const stripes = useStripes();
+
+    renderWithIntl(
+      <StripesContext.Provider value={stripes}>
+        <CalloutContext.Provider value={{ sendCallout: jest.fn() }}>
+          <MemoryRouter initialEntries={['/']}>
+            <AggregatorManager
+              {...actionMenuProps}
+              stripes={stripes}
+            />
+          </MemoryRouter>
+        </CalloutContext.Provider>
+      </StripesContext.Provider>
+    );
+
+    await userEvent.click(screen.getByRole('link', { name: aggregator.label }));
+    await userEvent.click(screen.getByRole('button', { name: /Actions/ }));
+
+    expect(screen.getByRole('button', { name: /Duplicate/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Edit/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete/ })).toBeInTheDocument();
   });
 });

--- a/translations/ui-erm-usage/en.json
+++ b/translations/ui-erm-usage/en.json
@@ -251,7 +251,6 @@
   "aggregator.config.addParam": "Add config parameter",
 
   "aggregator.form.create": "Create aggregator",
-  "aggregator.form.delete.confirm.title": "Delete aggregator",
   "aggregator.form.newAggregator": "New aggregator",
   "udp.form.delete.confirm.title": "Delete usage data Provider",
   "form.delete.confirm.message": "Do you really want to delete <strong>{name}</strong>?",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIEUS-527

### Description

As a user, I would like to be able to delete aggregator records in the settings directly from the detail view using an Actions menu, so that I don't have to switch to edit mode first. When I click the button, I want a pop-up window to appear warning me that I am about to delete the record.

**Use case**
Users must first switch to edit mode in order to delete the record. The Cross App SIG recommends placing the button in the record's detail view under the Actions menu, as this is the preferred location.

**Concept**
**Old position:** _Settings > Aggregators > Edit mode > top right corner_
The button must be removed.

**New position:** _Settings > Aggregators > Detail view_
Instead of the “Edit” button, an action menu is now used.
The Actions menu contains the following entries: Edit, Delete, Duplicate

**Acceptance criterias (UAT)**
- The delete button must be removed in edit mode.
- Detail view: The “Edit” button is no longer there.
- Detail view: There is a new “Actions” menu in the upper-right corner.
- Actions menu: The Actions menu contains the following entries Edit and Delete. The behavior of the entries when selected matches the description in the user story.
- The permissions must work.


### Approach

- Remove LastMenu, Confirmation Modal, delete function, delete state and delete button in `AggregatorForm.js`
- Enable Action menu by adding property `enableDetailsActionMenu` of `EntityManager`:
> If present and true, replaces the Edit button at top right of full records with an action menu offering Duplicate, Edit and Delete.
- Remove test for delete aggregator in `AggregatorForm.test.js`
- Add test for Action menu with available entries "Edit", "Duplicate" and "Delete".
-> Since the original purpose of this task was to make the delete button consistent with those in the other apps, no custom confirmation modal will be implemented (red delete button, custom modal message) here, knowing full well that it differs from the one we are using here https://github.com/folio-org/ui-erm-usage/pull/634